### PR TITLE
Use VTK 6.2

### DIFF
--- a/CMake/coredeps.cmake
+++ b/CMake/coredeps.cmake
@@ -61,6 +61,7 @@ set(VTK_REQUIRED_COMPONENTS
   vtkIOXML
   vtkRenderingAnnotation
   vtkRenderingContext2D
+  vtkRenderingContextOpenGL
   vtkRenderingFreeType
   vtkRenderingFreeTypeOpenGL
   vtkRenderingLabel
@@ -85,7 +86,7 @@ if(VISGUI_ENABLE_WEB)
   endif()
 endif()
 
-find_package(VTK NO_MODULE REQUIRED COMPONENTS ${VTK_REQUIRED_COMPONENTS})
+find_package(VTK 6.2 NO_MODULE REQUIRED COMPONENTS ${VTK_REQUIRED_COMPONENTS})
 include(${VTK_USE_FILE})
 
 # We need this definition to be set regardless

--- a/Libraries/VtkVgCore/CMakeLists.txt
+++ b/Libraries/VtkVgCore/CMakeLists.txt
@@ -195,6 +195,7 @@ vg_vtk_module(${PROJECT_NAME}
   vtkInteractionStyle
   vtkInfovisLayout
   vtkIOCore
+  vtkRenderingContextOpenGL
   vtkRenderingFreeTypeOpenGL
   vtkRenderingLabel
   vtkRenderingOpenGL


### PR DESCRIPTION
Modify dependencies to require exactly VTK 6.2. Add link to new VTK component `vtkRenderingContextOpenGL`, which fixes a `no override found for "vtkContextDevice2D"` error that causes us to crash at startup.

VTK has made breaking changes between each of 6.1, 6.2 and 6.3. Picking one and enforcing it both reduces user confusion (avoids issues caused by a "wrong" VTK version by making it explicit which one we expect) and avoids trying to work around the chicken-and-egg problem of needing to ask for different components depending on the VTK version when we need to first find VTK to know what version was found in order to make the build adaptable to the version of VTK in use.

For a description of the VTK 6.1 → 6.2 breaking change, see also: http://public.kitware.com/pipermail/vtk-developers/2014-July/030648.html
