### PR TITLE
Port track_oracle plugin to KWIVER

### DIFF
--- a/CMake/coredeps.cmake
+++ b/CMake/coredeps.cmake
@@ -118,6 +118,11 @@ if (VISGUI_ENABLE_VIDTK)
   add_definitions(-DUUIDABLE)
 endif()
 
+if (VISGUI_ENABLE_KWIVER)
+  find_package(kwiver REQUIRED)
+  add_definitions(-DVISGUI_USE_KWIVER)
+endif()
+
 # QtTesting is required for tests
 find_package(QtTesting QUIET)
 if(QtTesting_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(VISGUI_ENABLE_VSPLAY         "Build vsPlay application"              ON)
 option(VISGUI_ENABLE_GDAL           "Enable features that require GDAL"     OFF)
 option(VISGUI_ENABLE_KWPPT          "Enable features that require KWPPT"    OFF)
 option(VISGUI_ENABLE_VIDTK          "Enable features that require VidTK"    ON)
+option(VISGUI_ENABLE_KWIVER         "Enable features that require KWIVER"   ON)
 #   ...Python bindings
 option(VISGUI_ENABLE_PYTHON         "Enable VisGUI Python bindings"         OFF)
 #   ...Install options

--- a/Plugins/VspSourceService/CMakeLists.txt
+++ b/Plugins/VspSourceService/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 add_subdirectory(KwaArchiveSource)
 
 # Track source
-if(TARGET track_oracle)
+if(TARGET track_oracle OR TARGET kwiver::track_oracle)
   add_subdirectory(TrackOracleArchiveSource)
 elseif(vidtk_FOUND)
   add_subdirectory(Kw18ArchiveSource)

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/CMakeLists.txt
@@ -5,9 +5,13 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 vg_include_library_sdk_directories(vspSourceUtil)
-include_directories(SYSTEM
-  ${VIDTK_INCLUDE_DIRS}
-)
+
+if(TARGET kwiver::track_oracle)
+  include_directories(SYSTEM ${KWIVER_INCLUDE_DIRS})
+  add_definitions(-DKWIVER_TRACK_ORACLE)
+else()
+  include_directories(SYSTEM ${VIDTK_INCLUDE_DIRS})
+endif()
 
 set(vsTrackOracleArchiveSource_Sources
   vsTrackOracleArchiveSourcePlugin.cxx
@@ -29,9 +33,20 @@ vg_add_qt_plugin(${PROJECT_NAME}
   ${vsTrackOracleArchiveSource_MocSources}
 )
 
+if (TARGET kwiver::track_oracle)
+  target_link_libraries(${PROJECT_NAME}
+    kwiver::track_oracle
+    kwiver::track_oracle_file_formats
+  )
+else()
+  target_link_libraries(${PROJECT_NAME}
+    track_oracle
+    track_oracle_file_formats
+    ${QT_LIBRARIES}
+  )
+endif()
+
 target_link_libraries(${PROJECT_NAME}
-  track_oracle
-  track_oracle_file_formats
   vspSourceUtil
   ${QT_LIBRARIES}
 )

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/track_oracle_file_format_fwd.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/track_oracle_file_format_fwd.h
@@ -1,0 +1,34 @@
+/*ckwg +5
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __track_oracle_file_format_fwd_h
+#define __track_oracle_file_format_fwd_h
+
+#ifdef KWIVER_TRACK_ORACLE
+namespace kwiver
+{
+  namespace track_oracle
+  {
+    class file_format_base;
+  }
+}
+#else
+namespace vidtk
+{
+  class file_format_base;
+}
+#endif
+
+namespace track_oracle
+{
+#ifdef KWIVER_TRACK_ORACLE
+  using namespace kwiver::track_oracle;
+#else
+  using namespace vidtk;
+#endif
+}
+
+#endif

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/track_oracle_utils.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/track_oracle_utils.h
@@ -1,0 +1,46 @@
+/*ckwg +5
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __track_oracle_utils_h
+#define __track_oracle_utils_h
+
+#ifdef KWIVER_TRACK_ORACLE
+namespace kwiver
+{
+  namespace track_oracle
+  {
+    template <typename T> class track_field;
+  }
+}
+#else
+namespace vidtk
+{
+  template <typename T> class track_field;
+}
+#endif
+
+namespace track_oracle
+{
+#ifdef KWIVER_TRACK_ORACLE
+  using namespace kwiver::track_oracle;
+#else
+  using namespace vidtk;
+#endif
+
+  template <typename T>
+  struct track_field_type;
+
+  template <typename T>
+  struct track_field_type<track_oracle::track_field<T>&>
+  {
+    using type = T;
+  };
+}
+
+#define TRACK_ORACLE_INIT_FIELD(t, n) \
+  n(t.add_field<::track_oracle::track_field_type<decltype(n)>::type>(#n))
+
+#endif

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/visgui_event_type.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/visgui_event_type.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,63 +7,71 @@
 #ifndef __visgui_descriptor_type_h
 #define __visgui_descriptor_type_h
 
+#include "track_oracle_utils.h"
+
+#ifdef KWIVER_TRACK_ORACLE
+#include <track_oracle/core/track_base.h>
+#include <track_oracle/core/track_field.h>
+#else
 #include <track_oracle/track_base.h>
 #include <track_oracle/track_field.h>
+#endif
+
 #include <vgl/vgl_box_2d.h>
 
 //-----------------------------------------------------------------------------
 struct visgui_classifier_descriptor_type :
-  public vidtk::track_base<visgui_classifier_descriptor_type>
+  public track_oracle::track_base<visgui_classifier_descriptor_type>
 {
-  vidtk::track_field<unsigned int>& external_id;
-  vidtk::track_field<std::vector<unsigned int> >& source_track_ids;
-  vidtk::track_field<std::vector<double> >& descriptor_classifier;
+  track_oracle::track_field<unsigned int>& external_id;
+  track_oracle::track_field<std::vector<unsigned int>>& source_track_ids;
+  track_oracle::track_field<std::vector<double>>& descriptor_classifier;
 
-  vidtk::track_field<unsigned int>& frame_number;
-  vidtk::track_field<unsigned long long>& timestamp_usecs;
-  vidtk::track_field<vgl_box_2d<double> >& bounding_box;
+  track_oracle::track_field<unsigned int>& frame_number;
+  track_oracle::track_field<unsigned long long>& timestamp_usecs;
+  track_oracle::track_field<vgl_box_2d<double>>& bounding_box;
 
   visgui_classifier_descriptor_type() :
-    external_id(Track.add_field<unsigned int>("external_id")),
-    source_track_ids(Track.add_field<std::vector<unsigned int> >("source_track_ids")),
-    descriptor_classifier(Track.add_field<std::vector<double> >("descriptor_classifier")),
+    TRACK_ORACLE_INIT_FIELD(Track, external_id),
+    TRACK_ORACLE_INIT_FIELD(Track, source_track_ids),
+    TRACK_ORACLE_INIT_FIELD(Track, descriptor_classifier),
 
-    frame_number(Frame.add_field<unsigned int>("frame_number")),
-    timestamp_usecs(Frame.add_field< unsigned long long>("timestamp_usecs")),
-    bounding_box(Frame.add_field< vgl_box_2d<double> >("bounding_box"))
+    TRACK_ORACLE_INIT_FIELD(Frame, frame_number),
+    TRACK_ORACLE_INIT_FIELD(Frame, timestamp_usecs),
+    TRACK_ORACLE_INIT_FIELD(Frame, bounding_box)
     {
     }
 };
 
 //-----------------------------------------------------------------------------
 struct visgui_pvo_descriptor_type :
-  public vidtk::track_base<visgui_pvo_descriptor_type>
+  public track_oracle::track_base<visgui_pvo_descriptor_type>
 {
-  vidtk::track_field<std::vector<unsigned int> >& source_track_ids;
-  vidtk::track_field<std::vector<double> >& descriptor_pvo_raw_scores;
+  track_oracle::track_field<std::vector<unsigned int>>& source_track_ids;
+  track_oracle::track_field<std::vector<double>>& descriptor_pvo_raw_scores;
 
   visgui_pvo_descriptor_type() :
-    source_track_ids(Track.add_field<std::vector<unsigned int> >("source_track_ids")),
-    descriptor_pvo_raw_scores(Track.add_field<std::vector<double> >("descriptor_pvo_raw_scores"))
+    TRACK_ORACLE_INIT_FIELD(Track, source_track_ids),
+    TRACK_ORACLE_INIT_FIELD(Track, descriptor_pvo_raw_scores)
     {
     }
 };
 
 //-----------------------------------------------------------------------------
 struct visgui_generic_event_type :
-  public vidtk::track_base<visgui_generic_event_type,
-                           visgui_classifier_descriptor_type>
+  public track_oracle::track_base<visgui_generic_event_type,
+                                  visgui_classifier_descriptor_type>
 {
-  vidtk::track_field<double>& start_time_secs;
-  vidtk::track_field<double>& end_time_secs;
-  vidtk::track_field<std::string>& basic_annotation;
-  vidtk::track_field<std::string>& augmented_annotation;
+  track_oracle::track_field<double>& start_time_secs;
+  track_oracle::track_field<double>& end_time_secs;
+  track_oracle::track_field<std::string>& basic_annotation;
+  track_oracle::track_field<std::string>& augmented_annotation;
 
   visgui_generic_event_type() :
-    start_time_secs(Track.add_field<double>("start_time_secs")),
-    end_time_secs(Track.add_field<double>("end_time_secs")),
-    basic_annotation(Track.add_field<std::string>("basic_annotation")),
-    augmented_annotation(Track.add_field<std::string>("augmented_annotation"))
+    TRACK_ORACLE_INIT_FIELD(Track, start_time_secs),
+    TRACK_ORACLE_INIT_FIELD(Track, end_time_secs),
+    TRACK_ORACLE_INIT_FIELD(Track, basic_annotation),
+    TRACK_ORACLE_INIT_FIELD(Track, augmented_annotation)
     {
     }
 };

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/visgui_track_type.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/visgui_track_type.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2012 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,61 +7,69 @@
 #ifndef __visgui_track_type_h
 #define __visgui_track_type_h
 
+#include "track_oracle_utils.h"
+
+#ifdef KWIVER_TRACK_ORACLE
+#include <track_oracle/core/track_base.h>
+#include <track_oracle/core/track_field.h>
+#else
 #include <track_oracle/track_base.h>
 #include <track_oracle/track_field.h>
+#endif
+
 #include <vgl/vgl_box_2d.h>
 #include <vgl/vgl_point_2d.h>
 
 //-----------------------------------------------------------------------------
 struct visgui_base_track_type :
-  public vidtk::track_base<visgui_base_track_type>
+  public track_oracle::track_base<visgui_base_track_type>
 {
-  vidtk::track_field<unsigned int>& external_id;
-  vidtk::track_field<vgl_point_2d<double> >& obj_location;
-  vidtk::track_field<vgl_box_2d<double> >& bounding_box;
+  track_oracle::track_field<unsigned int>& external_id;
+  track_oracle::track_field<vgl_point_2d<double>>& obj_location;
+  track_oracle::track_field<vgl_box_2d<double>>& bounding_box;
 
   visgui_base_track_type() :
-    external_id(Track.add_field<unsigned int>("external_id")),
-    obj_location(Frame.add_field<vgl_point_2d<double> >("obj_location")),
-    bounding_box(Frame.add_field<vgl_box_2d<double> >("bounding_box"))
+    TRACK_ORACLE_INIT_FIELD(Track, external_id),
+    TRACK_ORACLE_INIT_FIELD(Frame, obj_location),
+    TRACK_ORACLE_INIT_FIELD(Frame, bounding_box)
     {
     }
 };
 
 //-----------------------------------------------------------------------------
 struct visgui_fn_track_type :
-  public vidtk::track_base<visgui_fn_track_type, visgui_base_track_type>
+  public track_oracle::track_base<visgui_fn_track_type, visgui_base_track_type>
 {
-  vidtk::track_field<unsigned>& frame_number;
+  track_oracle::track_field<unsigned>& frame_number;
 
   visgui_fn_track_type() :
-    frame_number(Frame.add_field<unsigned>("frame_number"))
+    TRACK_ORACLE_INIT_FIELD(Frame, frame_number)
     {
     }
 };
 
 //-----------------------------------------------------------------------------
 struct visgui_ts_track_type :
-  public vidtk::track_base<visgui_ts_track_type, visgui_base_track_type>
+  public track_oracle::track_base<visgui_ts_track_type, visgui_base_track_type>
 {
-  vidtk::track_field<unsigned long long>& timestamp_usecs;
+  track_oracle::track_field<unsigned long long>& timestamp_usecs;
 
   visgui_ts_track_type() :
-    timestamp_usecs(Frame.add_field<unsigned long long>("timestamp_usecs"))
+    TRACK_ORACLE_INIT_FIELD(Frame, timestamp_usecs)
     {
     }
 };
 
 //-----------------------------------------------------------------------------
 struct visgui_track_type :
-  public vidtk::track_base<visgui_track_type, visgui_base_track_type>
+  public track_oracle::track_base<visgui_track_type, visgui_base_track_type>
 {
-  vidtk::track_field<unsigned long long>& timestamp_usecs;
-  vidtk::track_field<unsigned>& frame_number;
+  track_oracle::track_field<unsigned long long>& timestamp_usecs;
+  track_oracle::track_field<unsigned>& frame_number;
 
   visgui_track_type() :
-    timestamp_usecs(Frame.add_field<unsigned long long>("timestamp_usecs")),
-    frame_number(Frame.add_field<unsigned>("frame_number"))
+    TRACK_ORACLE_INIT_FIELD(Frame, timestamp_usecs),
+    TRACK_ORACLE_INIT_FIELD(Frame, frame_number)
     {
     }
 };

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleArchiveSourcePlugin.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleArchiveSourcePlugin.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleDescriptorArchiveSource.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleDescriptorArchiveSource.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -11,10 +11,7 @@
 
 #include <vsArchiveSource.h>
 
-namespace vidtk
-{
-  class file_format_base;
-}
+#include "track_oracle_file_format_fwd.h"
 
 class vsTrackOracleDescriptorArchiveSourcePrivate;
 
@@ -25,7 +22,7 @@ class vsTrackOracleDescriptorArchiveSource :
 
 public:
   vsTrackOracleDescriptorArchiveSource(const QUrl& archiveUri,
-                                       vidtk::file_format_base* format);
+                                       track_oracle::file_format_base* format);
   virtual ~vsTrackOracleDescriptorArchiveSource();
 
 private:

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleTrackArchiveSource.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleTrackArchiveSource.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -11,10 +11,7 @@
 
 #include <vsArchiveSource.h>
 
-namespace vidtk
-{
-  class file_format_base;
-}
+#include "track_oracle_file_format_fwd.h"
 
 class vsTrackOracleTrackArchiveSourcePrivate;
 
@@ -24,7 +21,7 @@ class vsTrackOracleTrackArchiveSource : public vsArchiveSource<vsTrackSource>
 
 public:
   vsTrackOracleTrackArchiveSource(const QUrl& archiveUri,
-                                  vidtk::file_format_base* format);
+                                  track_oracle::file_format_base* format);
   virtual ~vsTrackOracleTrackArchiveSource();
 
 private:


### PR DESCRIPTION
Port the vsPlay track_oracle plugin to support use of the [KWIVER](http://kwiver.org) version of track_oracle. This makes it possible to use the plugin with the publicly available version of track_oracle (which is in KWIVER).

In theory, these changes are backwards-compatible, i.e. will still work with the old vidk track_oracle, although this has not been tested, and we may eventually remove that support, since KWIVER is the path of active development.