### PR TITLE
Separately track keyframes in WAMI Viewer

### DIFF
--- a/Applications/VpView/CMakeLists.txt
+++ b/Applications/VpView/CMakeLists.txt
@@ -145,6 +145,7 @@ set(vpViewSources
   vpVideoAnimation.cxx
   vpView.cxx
   vpViewCore.cxx
+  vtkVpTrackModel.cxx
 )
 
 set(vpViewUI
@@ -197,6 +198,7 @@ set(vpViewHeaders
   vpVideoAnimation.h
   vpView.h
   vpViewCore.h
+  vtkVpTrackModel.h
 )
 
 set(vpViewResources ../../Icons/vpView.qrc)

--- a/Applications/VpView/vpFileTrackIO.cxx
+++ b/Applications/VpView/vpFileTrackIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -11,7 +11,7 @@
 
 //-----------------------------------------------------------------------------
 vpFileTrackIO::vpFileTrackIO(vpFileReader& reader,
-                             vtkVgTrackModel* trackModel,
+                             vtkVpTrackModel* trackModel,
                              TrackStorageMode storageMode,
                              TrackTimeStampMode timeStampMode,
                              vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpFileTrackIO.h
+++ b/Applications/VpView/vpFileTrackIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -15,7 +15,7 @@ class vpFileTrackIO : public vpTrackIO
 {
 public:
   vpFileTrackIO(vpFileReader& reader,
-                vtkVgTrackModel* trackModel,
+                vtkVpTrackModel* trackModel,
                 TrackStorageMode storageMode,
                 TrackTimeStampMode timeStampMode,
                 vtkVgTrackTypeRegistry* trackTypes = 0,

--- a/Applications/VpView/vpFileTrackIOImpl.cxx
+++ b/Applications/VpView/vpFileTrackIOImpl.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,9 +7,9 @@
 #include "vpFileTrackIOImpl.h"
 
 #include "vpTrackIO.h"
+#include "vtkVpTrackModel.h"
 
 #include <vtkVgTrack.h>
-#include <vtkVgTrackModel.h>
 #include <vtkVgTrackTypeRegistry.h>
 
 #include <vtkPoints.h>
@@ -135,16 +135,9 @@ bool vpFileTrackIOImpl::ImportSupplementalFiles(vpTrackIO* io,
       vtkVgTimeStamp ts;
       ts.SetFrameNumber(frame);
 
-      // "Delete" frames from the track that we now know are interpolated. The
-      // track code will re-generate the interpolated frames, which is
-      // inefficient, but this is the only way (currently) to preserve the
-      // information about which frames are true keyframes. We want to keep
-      // track of this info since it will make the annotators' lives easier.
-      if (!isKeyFrame)
+      if (isKeyFrame)
         {
-        track->DeletePoint(ts, true);
-        file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-        continue;
+        io->TrackModel->AddKeyframe(id, ts);
         }
 
       points.reserve(numPoints * 3);

--- a/Applications/VpView/vpFseIO.cxx
+++ b/Applications/VpView/vpFseIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -22,7 +22,7 @@ vpFseIO::~vpFseIO()
 }
 
 //-----------------------------------------------------------------------------
-void vpFseIO::SetTrackModel(vtkVgTrackModel* trackModel,
+void vpFseIO::SetTrackModel(vtkVpTrackModel* trackModel,
                             vpTrackIO::TrackStorageMode storageMode,
                             vpTrackIO::TrackTimeStampMode timeStampMode,
                             vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpFseIO.h
+++ b/Applications/VpView/vpFseIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -18,7 +18,7 @@ public:
   vpFseIO();
   virtual ~vpFseIO();
 
-  virtual void SetTrackModel(vtkVgTrackModel* trackModel,
+  virtual void SetTrackModel(vtkVpTrackModel* trackModel,
                              vpTrackIO::TrackStorageMode storageMode,
                              vpTrackIO::TrackTimeStampMode timeStampMode,
                              vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpFseTrackIO.cxx
+++ b/Applications/VpView/vpFseTrackIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,10 +7,10 @@
 #include "vpFseTrackIO.h"
 
 #include "vpFrameMap.h"
+#include "vtkVpTrackModel.h"
 
 #include <vtkVgScalars.h>
 #include <vtkVgTrack.h>
-#include <vtkVgTrackModel.h>
 #include <vtkVgTrackTypeRegistry.h>
 #include <vtkVgTypeDefs.h>
 
@@ -23,7 +23,7 @@
 #include <json.h>
 
 //-----------------------------------------------------------------------------
-vpFseTrackIO::vpFseTrackIO(vtkVgTrackModel* trackModel,
+vpFseTrackIO::vpFseTrackIO(vtkVpTrackModel* trackModel,
                            TrackStorageMode storageMode,
                            TrackTimeStampMode timeStampMode,
                            vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpFseTrackIO.h
+++ b/Applications/VpView/vpFseTrackIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -16,7 +16,7 @@ class vtkVgTrack;
 class vpFseTrackIO : public vpTrackIO
 {
 public:
-  vpFseTrackIO(vtkVgTrackModel* trackModel,
+  vpFseTrackIO(vtkVpTrackModel* trackModel,
                vpTrackIO::TrackStorageMode storageMode,
                vpTrackIO::TrackTimeStampMode timeStampMode,
                vtkVgTrackTypeRegistry* trackTypes = 0,

--- a/Applications/VpView/vpMergeTracksDialog.cxx
+++ b/Applications/VpView/vpMergeTracksDialog.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -10,11 +10,11 @@
 
 #include "vpUtils.h"
 #include "vpViewCore.h"
+#include "vtkVpTrackModel.h"
 
 #include <vtkVgEvent.h>
 #include <vtkVgEventModel.h>
 #include <vtkVgTrack.h>
-#include <vtkVgTrackModel.h>
 
 #include <QCheckBox>
 #include <QDebug>
@@ -40,7 +40,7 @@ public:
   int Session;
 
   vpViewCore* ViewCore;
-  vtkSmartPointer<vtkVgTrackModel> TrackModel;
+  vtkSmartPointer<vtkVpTrackModel> TrackModel;
 
   bool AutoExtendEvents;
   bool AutoMergeEvents;

--- a/Applications/VpView/vpModelIO.h
+++ b/Applications/VpView/vpModelIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -22,7 +22,7 @@ public:
   vpModelIO();
   virtual ~vpModelIO() {}
 
-  virtual void SetTrackModel(vtkVgTrackModel* trackModel,
+  virtual void SetTrackModel(vtkVpTrackModel* trackModel,
                              vpTrackIO::TrackStorageMode storageMode,
                              vpTrackIO::TrackTimeStampMode timeStampMode,
                              vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpObjectInfoPanel.cxx
+++ b/Applications/VpView/vpObjectInfoPanel.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -25,11 +25,11 @@
 #include "vpTrackIO.h"
 #include "vpUtils.h"
 #include "vpViewCore.h"
+#include "vtkVpTrackModel.h"
 
 #include "vtkVgActivityManager.h"
 #include "vtkVgEventModel.h"
 #include "vtkVgEventTypeRegistry.h"
-#include "vtkVgTrackModel.h"
 
 #include "vtkVgActivity.h"
 #include "vtkVgEvent.h"
@@ -81,7 +81,7 @@ void vpObjectInfoPanel::ShowEmptyPage()
 void vpObjectInfoPanel::Initialize(vpViewCore* viewCore,
                                    vtkVgActivityManager* activityManager,
                                    vtkVgEventModel* eventModel,
-                                   vtkVgTrackModel* trackModel,
+                                   vtkVpTrackModel* trackModel,
                                    vtkVgEventTypeRegistry* eventTypes,
                                    vpTrackConfig* trackTypes,
                                    const vpTrackIO* trackIO)
@@ -411,9 +411,7 @@ void vpObjectInfoPanel::EditTrackInfo()
       else
         {
         // update the id
-        this->TrackModel->RemoveTrack(this->Track->GetId());
-        this->Track->SetId(id);
-        this->TrackModel->AddTrack(this->Track);
+        this->TrackModel->SetTrackId(this->Track, id);
         emit this->ObjectIdChanged(objectType, this->Track->GetId());
         }
       }

--- a/Applications/VpView/vpObjectInfoPanel.h
+++ b/Applications/VpView/vpObjectInfoPanel.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -22,12 +22,12 @@ class vpObjectInfoPanel;
 class vpTrackConfig;
 class vpTrackIO;
 class vpViewCore;
+class vtkVpTrackModel;
 class vtkVgActivityManager;
 class vtkVgEvent;
 class vtkVgEventModel;
 class vtkVgEventTypeRegistry;
 class vtkVgTrack;
-class vtkVgTrackModel;
 
 class vpObjectInfoPanel : public QWidget
 {
@@ -44,7 +44,7 @@ public:
   void ShowEmptyPage();
 
   void Initialize(vpViewCore* viewCore, vtkVgActivityManager* activityManager,
-                  vtkVgEventModel* eventModel, vtkVgTrackModel* trackModel,
+                  vtkVgEventModel* eventModel, vtkVpTrackModel* trackModel,
                   vtkVgEventTypeRegistry* eventTypes, vpTrackConfig* trackTypes,
                   const vpTrackIO* trackIO);
 
@@ -86,11 +86,11 @@ private:
   vpViewCore*            ViewCoreInstance;
   vtkVgActivityManager*  ActivityManager;
   vtkVgEventModel*       EventModel;
-  vtkVgTrackModel*       TrackModel;
+  vtkVpTrackModel*       TrackModel;
   const vpTrackIO*       TrackIO;
 
   vtkVgEventTypeRegistry* EventTypeRegistry;
-  vpTrackConfig* TrackConfig;;
+  vpTrackConfig* TrackConfig;
 
   int TrackIndex;
   vtkSmartPointer<vtkVgTrack> Track;

--- a/Applications/VpView/vpObjectSelectionPanel.cxx
+++ b/Applications/VpView/vpObjectSelectionPanel.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -10,6 +10,7 @@
 
 #include "vgEventType.h"
 #include "vpViewCore.h"
+#include "vtkVpTrackModel.h"
 
 #include "vtkVgActivity.h"
 #include "vtkVgActivityManager.h"
@@ -18,7 +19,6 @@
 #include "vtkVgEventTypeRegistry.h"
 #include "vtkVgRendererUtils.h"
 #include "vtkVgTrack.h"
-#include "vtkVgTrackModel.h"
 #include "vtkVgTrackTypeRegistry.h"
 
 #include <vtkIdList.h>
@@ -217,7 +217,7 @@ inline vpTreeView* vpObjectSelectionPanel::CurrentTree()
 void vpObjectSelectionPanel::Initialize(vpViewCore* viewCore,
                                         vtkVgActivityManager* activityManager,
                                         vtkVgEventModel* eventModel,
-                                        vtkVgTrackModel* trackModel,
+                                        vtkVpTrackModel* trackModel,
                                         vtkVgEventFilter* eventFilter,
                                         vtkVgTrackFilter* trackFilter,
                                         vtkVgEventTypeRegistry* eventTypes,
@@ -510,7 +510,10 @@ void vpObjectSelectionPanel::OnTreeContextMenu(QMenu& menu)
 
         vtkVgTimeStamp splitTime = this->ViewCoreInstance->getCoreTimeStamp();
 
-        a->setEnabled(!track->GetFrameIsInterpolated(splitTime) &&
+        const bool isKeyframe =
+          this->TrackModel->GetIsKeyframe(this->SelectedItem.Id, splitTime);
+
+        a->setEnabled(isKeyframe &&
                       track->GetStartFrame() < splitTime &&
                       track->GetEndFrame() > splitTime);
         }

--- a/Applications/VpView/vpObjectSelectionPanel.h
+++ b/Applications/VpView/vpObjectSelectionPanel.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -20,6 +20,7 @@ class vpObjectSelectionPanel;
 
 class vpViewCore;
 class vpTreeView;
+class vtkVpTrackModel;
 class vtkIdList;
 class vtkVgActivityManager;
 class vtkVgEventFilter;
@@ -27,7 +28,6 @@ class vtkVgEventModel;
 class vtkVgEventTypeRegistry;
 class vtkVgTimeStamp;
 class vtkVgTrackFilter;
-class vtkVgTrackModel;
 class vtkVgTrackTypeRegistry;
 
 class QMenu;
@@ -53,7 +53,7 @@ public:
   void Initialize(vpViewCore* viewCore,
                   vtkVgActivityManager* activityManager,
                   vtkVgEventModel* eventModel,
-                  vtkVgTrackModel* trackModel,
+                  vtkVpTrackModel* trackModel,
                   vtkVgEventFilter* eventFilter,
                   vtkVgTrackFilter* trackFilter,
                   vtkVgEventTypeRegistry* eventTypes,
@@ -212,7 +212,7 @@ private:
   vpViewCore*            ViewCoreInstance;
   vtkVgActivityManager*  ActivityManager;
   vtkVgEventModel*       EventModel;
-  vtkVgTrackModel*       TrackModel;
+  vtkVpTrackModel*       TrackModel;
 
   vtkVgEventTypeRegistry* EventTypeRegistry;
   vtkVgTrackTypeRegistry* TrackTypeRegistry;

--- a/Applications/VpView/vpProject.cxx
+++ b/Applications/VpView/vpProject.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,6 +7,7 @@
 #include "vpProject.h"
 
 #include "vpModelIO.h"
+#include "vtkVpTrackModel.h"
 
 #include <vtkVgActivityManager.h>
 #include <vtkVgEventIconRepresentation.h>
@@ -16,7 +17,6 @@
 #include <vtkVgIconManager.h>
 #include <vtkVgPicker.h>
 #include <vtkVgTrackHeadRepresentation.h>
-#include <vtkVgTrackModel.h>
 #include <vtkVgTrackRepresentation.h>
 
 //-----------------------------------------------------------------------------
@@ -102,7 +102,7 @@ vpProject::vpProject(int id) :
 
   this->FrameNumberOffset = 0;
 
-  this->TrackModel = vtkSmartPointer<vtkVgTrackModel>::New();
+  this->TrackModel = vtkSmartPointer<vtkVpTrackModel>::New();
   this->TrackRepresentation = vtkSmartPointer<vtkVgTrackRepresentation>::New();
   this->SelectedTrackRepresentation =
     vtkSmartPointer<vtkVgTrackRepresentation>::New();

--- a/Applications/VpView/vpProject.h
+++ b/Applications/VpView/vpProject.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -28,9 +28,10 @@ class vtkVgEventRepresentation;
 class vtkVgIconManager;
 class vtkVgPicker;
 class vtkVgTrackHeadRepresentation;
-class vtkVgTrackModel;
 class vtkVgTrackRepresentation;
+
 class vtkVpReaderBase;
+class vtkVpTrackModel;
 
 class vpProject
 {
@@ -147,7 +148,7 @@ public:
 
   // Description:
   // Project specific models and representations
-  vtkSmartPointer<vtkVgTrackModel> TrackModel;
+  vtkSmartPointer<vtkVpTrackModel> TrackModel;
   vtkSmartPointer<vtkVgTrackRepresentation> TrackRepresentation;
   vtkSmartPointer<vtkVgTrackRepresentation> SelectedTrackRepresentation;
   vtkSmartPointer<vtkVgTrackHeadRepresentation> TrackHeadRepresentation;

--- a/Applications/VpView/vpSessionView.cxx
+++ b/Applications/VpView/vpSessionView.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -66,7 +66,7 @@ vpSessionView::~vpSessionView()
 void vpSessionView::AddSession(vpViewCore* viewCore,
                                vtkVgActivityManager* activityManager,
                                vtkVgEventModel* eventModel,
-                               vtkVgTrackModel* trackModel,
+                               vtkVpTrackModel* trackModel,
                                vtkVgEventFilter* eventFilter,
                                vtkVgTrackFilter* trackFilter,
                                vtkVgEventTypeRegistry* eventTypes,

--- a/Applications/VpView/vpSessionView.h
+++ b/Applications/VpView/vpSessionView.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -17,11 +17,12 @@
 
 class vpViewCore;
 
+class vtkVpTrackModel;
+
 class vtkIdList;
 
 class vtkVgActivityManager;
 class vtkVgEventModel;
-class vtkVgTrackModel;
 
 class QListWidget;
 class QListWidgetItem;
@@ -39,7 +40,7 @@ public:
   void AddSession(vpViewCore* viewCore,
                   vtkVgActivityManager* activityManager,
                   vtkVgEventModel* eventModel,
-                  vtkVgTrackModel* trackModel,
+                  vtkVpTrackModel* trackModel,
                   vtkVgEventFilter* eventFilter,
                   vtkVgTrackFilter* trackFilter,
                   vtkVgEventTypeRegistry* eventTypes,

--- a/Applications/VpView/vpTrackIO.cxx
+++ b/Applications/VpView/vpTrackIO.cxx
@@ -33,7 +33,7 @@ static const unsigned char DefaultTrackColors[NumDefaultTrackColors][3] =
 };
 
 //-----------------------------------------------------------------------------
-vpTrackIO::vpTrackIO(vtkVgTrackModel* trackModel,
+vpTrackIO::vpTrackIO(vtkVpTrackModel* trackModel,
                      TrackStorageMode storageMode,
                      TrackTimeStampMode timeStampMode,
                      vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpTrackIO.h
+++ b/Applications/VpView/vpTrackIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -11,9 +11,10 @@
 
 class vpFrameMap;
 
+class vtkVpTrackModel;
+
 class vtkVgTimeStamp;
 class vtkVgTrack;
-class vtkVgTrackModel;
 class vtkVgTrackTypeRegistry;
 
 class vtkMatrix4x4;
@@ -44,7 +45,7 @@ public:
     };
 
 public:
-  vpTrackIO(vtkVgTrackModel* trackModel,
+  vpTrackIO(vtkVpTrackModel* trackModel,
             TrackStorageMode storageMode,
             TrackTimeStampMode timeStampMode,
             vtkVgTrackTypeRegistry* trackTypes,
@@ -81,7 +82,7 @@ protected:
 protected:
   friend class vpFileTrackIOImpl;
 
-  vtkVgTrackModel* TrackModel;
+  vtkVpTrackModel* TrackModel;
   vtkVgTrackTypeRegistry* TrackTypes;
 
   TrackStorageMode StorageMode;

--- a/Applications/VpView/vpVidtkFileIO.cxx
+++ b/Applications/VpView/vpVidtkFileIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -23,7 +23,7 @@ vpVidtkFileIO::~vpVidtkFileIO()
 }
 
 //-----------------------------------------------------------------------------
-void vpVidtkFileIO::SetTrackModel(vtkVgTrackModel* trackModel,
+void vpVidtkFileIO::SetTrackModel(vtkVpTrackModel* trackModel,
                                   vpTrackIO::TrackStorageMode storageMode,
                                   vpTrackIO::TrackTimeStampMode timeStampMode,
                                   vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpVidtkFileIO.h
+++ b/Applications/VpView/vpVidtkFileIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -17,7 +17,7 @@ public:
   vpVidtkFileIO();
   virtual ~vpVidtkFileIO();
 
-  virtual void SetTrackModel(vtkVgTrackModel* trackModel,
+  virtual void SetTrackModel(vtkVpTrackModel* trackModel,
                              vpTrackIO::TrackStorageMode storageMode,
                              vpTrackIO::TrackTimeStampMode timeStampMode,
                              vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpVidtkFileTrackIO.cxx
+++ b/Applications/VpView/vpVidtkFileTrackIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -14,7 +14,7 @@ vpVidtkFileTrackIO::vpVidtkFileTrackIO(
   vpVidtkFileReader& reader,
   vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
   vcl_map<unsigned int, vtkIdType>& sourceIdToModelIdMap,
-  vtkVgTrackModel* trackModel,
+  vtkVpTrackModel* trackModel,
   TrackStorageMode storageMode,
   TrackTimeStampMode timeStampMode,
   vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpVidtkFileTrackIO.h
+++ b/Applications/VpView/vpVidtkFileTrackIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -17,7 +17,7 @@ public:
   vpVidtkFileTrackIO(vpVidtkFileReader& reader,
                      vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
                      vcl_map<unsigned int, vtkIdType>& sourceIdToModelIdMap,
-                     vtkVgTrackModel* trackModel,
+                     vtkVpTrackModel* trackModel,
                      TrackStorageMode storageMode,
                      TrackTimeStampMode timeStampMode,
                      vtkVgTrackTypeRegistry* trackTypes = 0,

--- a/Applications/VpView/vpVidtkIO.cxx
+++ b/Applications/VpView/vpVidtkIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -20,7 +20,7 @@ vpVidtkIO::~vpVidtkIO()
 }
 
 //-----------------------------------------------------------------------------
-void vpVidtkIO::SetTrackModel(vtkVgTrackModel* trackModel,
+void vpVidtkIO::SetTrackModel(vtkVpTrackModel* trackModel,
                               vpTrackIO::TrackStorageMode storageMode,
                               vpTrackIO::TrackTimeStampMode timeStampMode,
                               vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpVidtkIO.h
+++ b/Applications/VpView/vpVidtkIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -22,7 +22,7 @@ class vpVidtkIO : public vpModelIO
 public:
   virtual ~vpVidtkIO();
 
-  virtual void SetTrackModel(vtkVgTrackModel* trackModel,
+  virtual void SetTrackModel(vtkVpTrackModel* trackModel,
                              vpTrackIO::TrackStorageMode storageMode,
                              vpTrackIO::TrackTimeStampMode timeStampMode,
                              vtkVgTrackTypeRegistry* trackTypes,

--- a/Applications/VpView/vpVidtkTrackIO.cxx
+++ b/Applications/VpView/vpVidtkTrackIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -8,10 +8,10 @@
 
 #include "vpFrameMap.h"
 #include "vpVidtkReader.h"
+#include "vtkVpTrackModel.h"
 
 #include <vtkVgScalars.h>
 #include <vtkVgTrack.h>
-#include <vtkVgTrackModel.h>
 #include <vtkVgTrackTypeRegistry.h>
 
 #include <vtkBoundingBox.h>
@@ -30,7 +30,7 @@ vpVidtkTrackIO::vpVidtkTrackIO(vpVidtkReader& reader,
                                vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
                                vcl_map<unsigned int, vtkIdType>&
                                  sourceIdToModelIdMap,
-                               vtkVgTrackModel* trackModel,
+                               vtkVpTrackModel* trackModel,
                                TrackStorageMode storageMode,
                                TrackTimeStampMode timeStampMode,
                                vtkVgTrackTypeRegistry* trackTypes,
@@ -244,7 +244,8 @@ bool vpVidtkTrackIO::WriteTracks(const char* filename,
       vtkIdType* headPts;
       modelTrack->GetHeadIdentifier(ts, nHeadPts, headPts, trackPtId);
 
-      bool frameIsInterpolated = modelTrack->GetFrameIsInterpolated(ts);
+      const bool frameIsInterpolated =
+        !this->TrackModel->GetIsKeyframe(modelTrack->GetId(), ts);
 
       // Don't export frames without regions
       if (nHeadPts == 0)

--- a/Applications/VpView/vpVidtkTrackIO.h
+++ b/Applications/VpView/vpVidtkTrackIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -20,7 +20,7 @@ public:
   vpVidtkTrackIO(vpVidtkReader& reader,
                  vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
                  vcl_map<unsigned int, vtkIdType>& sourceIdToModelIdMap,
-                 vtkVgTrackModel* trackModel,
+                 vtkVpTrackModel* trackModel,
                  vpTrackIO::TrackStorageMode storageMode,
                  vpTrackIO::TrackTimeStampMode timeStampMode,
                  vtkVgTrackTypeRegistry* trackTypes = 0,

--- a/Applications/VpView/vpView.cxx
+++ b/Applications/VpView/vpView.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -37,12 +37,12 @@
 #include "vpVersion.h"
 #include "vpView.h"
 #include "vpViewCore.h"
+#include "vtkVpTrackModel.h"
 
 #include <vtkVgEvent.h>
 #include <vtkVgEventFilter.h>
 #include <vtkVgEventModel.h>
 #include <vtkVgTemporalFilters.h>
-#include <vtkVgTrackModel.h>
 #include <vtkVgTrackRepresentationBase.h>
 
 #include <QVTKWidget.h>

--- a/Applications/VpView/vpViewCore.h
+++ b/Applications/VpView/vpViewCore.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -59,7 +59,6 @@ class vtkVgRepresentationBase;
 class vtkVgTemporalFilters;
 class vtkVgTrack;
 class vtkVgTrackFilter;
-class vtkVgTrackModel;
 class vtkVgTrackTypeRegistry;
 
 class QVTKWidget;
@@ -97,6 +96,8 @@ class vpSessionView;
 class vpTimelineDialog;
 class vpTrackConfig;
 class vpVideoAnimation;
+
+class vtkVpTrackModel;
 
 // STL includes.
 #include <vector> // STL required.
@@ -284,7 +285,7 @@ public:
   void setImageSourceLevelOfDetailFactor(double factor);
   bool hasMultiLevelOfDetailSource();
 
-  vtkVgTrackModel* getTrackModel(int session);
+  vtkVpTrackModel* getTrackModel(int session);
   vtkVgEventModel* getEventModel(int session);
 
   vtkVgEventFilter* getEventFilter();

--- a/Applications/VpView/vtkVpTrackModel.cxx
+++ b/Applications/VpView/vtkVpTrackModel.cxx
@@ -1,0 +1,82 @@
+/*ckwg +5
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "vtkVpTrackModel.h"
+
+#include <vtkObjectFactory.h>
+
+vtkStandardNewMacro(vtkVpTrackModel);
+
+//-----------------------------------------------------------------------------
+vtkVpTrackModel::vtkVpTrackModel() : vtkVgTrackModel()
+{
+}
+
+//-----------------------------------------------------------------------------
+vtkVpTrackModel::~vtkVpTrackModel()
+{
+}
+
+//-----------------------------------------------------------------------------
+void vtkVpTrackModel::RemoveTrack(vtkIdType trackId)
+{
+  this->vtkVgTrackModel::RemoveTrack(trackId);
+  this->TrackKeyframes.erase(trackId);
+}
+
+//-----------------------------------------------------------------------------
+void vtkVpTrackModel::AddKeyframe(
+  vtkIdType trackId, const vtkVgTimeStamp& timeStamp)
+{
+  auto& trackKeyframes = this->TrackKeyframes[trackId];
+  trackKeyframes.insert(timeStamp);
+}
+
+//-----------------------------------------------------------------------------
+void vtkVpTrackModel::RemoveKeyframe(
+  vtkIdType trackId, const vtkVgTimeStamp& timeStamp)
+{
+    auto& trackKeyframes = this->TrackKeyframes[trackId];
+    trackKeyframes.erase(timeStamp);
+}
+
+//-----------------------------------------------------------------------------
+bool vtkVpTrackModel::GetIsKeyframe(
+  vtkIdType trackId, const vtkVgTimeStamp& timeStamp) const
+{
+  const auto& trackKeyframesIter = this->TrackKeyframes.find(trackId);
+  if (trackKeyframesIter != this->TrackKeyframes.end())
+    {
+    const auto& trackKeyframes = trackKeyframesIter->second;
+    const auto& keyframeIter = trackKeyframes.find(timeStamp);
+    return keyframeIter != trackKeyframes.end();
+    }
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+void vtkVpTrackModel::SetTrackId(vtkVgTrack* track, vtkIdType newId)
+{
+  const auto oldId = track->GetId();
+
+  this->vtkVgTrackModel::RemoveTrack(oldId);
+  track->SetId(newId);
+  this->vtkVgTrackModel::AddTrack(track);
+
+  const auto& tkfIter = this->TrackKeyframes.find(oldId);
+  if (tkfIter != this->TrackKeyframes.end())
+    {
+#if __cplusplus >= 201703L
+    auto tkfNode = this->TrackKeyframes.extract(tkfIter);
+    tkfNode.key() = newId;
+    this->TrackKeyframes.insert(strd::move(tkfNode));
+#else
+    const auto& trackKeyframes = tkfIter->second;
+    this->TrackKeyframes.emplace(newId, trackKeyframes);
+    this->TrackKeyframes.erase(oldId);
+#endif
+    }
+}

--- a/Applications/VpView/vtkVpTrackModel.h
+++ b/Applications/VpView/vtkVpTrackModel.h
@@ -1,0 +1,44 @@
+/*ckwg +5
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __vtkVpTrackModel_h
+#define __vtkVpTrackModel_h
+
+#include "vtkVgTrackModel.h"
+
+#include <set>
+#include <unordered_map>
+
+class vtkVpTrackModel : public vtkVgTrackModel
+{
+public:
+  static vtkVpTrackModel* New();
+  vtkTypeMacro(vtkVpTrackModel, vtkVgTrackModel);
+
+  void SetTrackId(vtkVgTrack* track, vtkIdType newId);
+
+  bool GetIsKeyframe(vtkIdType trackId, const vtkVgTimeStamp& timeStamp) const;
+
+  void AddKeyframe(vtkIdType trackId, const vtkVgTimeStamp& timeStamp);
+  void RemoveKeyframe(vtkIdType trackId, const vtkVgTimeStamp& timeStamp);
+
+  void RemoveTrack(vtkIdType trackId);
+
+protected:
+  // Description:
+  // Constructor / Destructor.
+  vtkVpTrackModel();
+  virtual ~vtkVpTrackModel();
+
+private:
+  vtkVpTrackModel(const vtkVpTrackModel&);  // Not implemented.
+  void operator=(const vtkVpTrackModel&);  // Not implemented.
+
+  using frame_set = std::set<vtkVgTimeStamp>;
+  std::unordered_map<vtkIdType, frame_set> TrackKeyframes;
+};
+
+#endif // __vpFseTrackIO_h

--- a/Libraries/VtkVgModelView/vtkVgTrackModel.h
+++ b/Libraries/VtkVgModelView/vtkVgTrackModel.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -159,12 +159,13 @@ public:
 
   void UpdateColorOfTracksOfType(int typeIndex, double *rgb);
 
+protected:
+  vtkVgTrackModel();
+  ~vtkVgTrackModel();
+
 private:
   vtkVgTrackModel(const vtkVgTrackModel&); // Not implemented.
   void operator=(const vtkVgTrackModel&);  // Not implemented.
-
-  vtkVgTrackModel();
-  ~vtkVgTrackModel();
 
   void SetAllTracksDisplayState(bool state);
 


### PR DESCRIPTION
Create a subclass of `vtkVgTrackModel` that separately tracks which frames are keyframes. This will allow us to provide "interpolated" frames via other mechanisms than the interpolation built into `vtkVgTrack` while still tracking which frames are keyframes, and without requiring deep modification of `vtkVgTrack` or affecting other users of the lower level classes.

This is a precursor to providing Algorithm-Assisted Annotation in WAMI Viewer, that is being pushed separately because it touches a broad section of the code. Separating this out should make reviewing the upcoming changes easier.