### PR TITLE
Update use of GeographicLib

### DIFF
--- a/Applications/Viqui/CMakeLists.txt
+++ b/Applications/Viqui/CMakeLists.txt
@@ -27,7 +27,6 @@ include_directories(SYSTEM
   ${KML_INCLUDE_DIRS}
   ${QtTesting_INCLUDE_DIRS}
   ${VTK_INCLUDE_DIRS}
-  ${GeographicLib_INCLUDE_DIRS}
   ${PROJ4_INCLUDE_DIR}
 )
 

--- a/Applications/VpView/CMakeLists.txt
+++ b/Applications/VpView/CMakeLists.txt
@@ -36,7 +36,6 @@ include_directories(SYSTEM
   ${Boost_INCLUDE_DIRS}
   ${LIBJSON_INCLUDE_DIR}
   ${VTK_INCLUDE_DIRS}
-  ${GeographicLib_INCLUDE_DIRS}
 )
 
 if(VISGUI_ENABLE_VIDTK)
@@ -261,7 +260,7 @@ add_executable(${PROJECT_NAME} ${ExecProperties}
 target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
   ${vgSdkTargets}
   vgl vnl vul vil_io
-  ${GeographicLib_LIBRARIES}
+  GeographicLib::GeographicLib
   ${VTK_OPENGL_RENDERING_COMPONENTS}
   vtkChartsCore vtkCommonColor vtkCommonSystem vtkInfovisCore
   vtkRenderingAnnotation vtkRenderingCore vtkGUISupportQt

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -7816,7 +7816,7 @@ double vpViewCore::getGeoDistance(double imagePt1[4], double imagePt2[4],
     }
   else
     {
-    GeographicLib::Geodesic::WGS84.Inverse(
+    GeographicLib::Geodesic::WGS84().Inverse(
       northing1, easting1, northing2, easting2, distance);
     }
 

--- a/CMake/coredeps.cmake
+++ b/CMake/coredeps.cmake
@@ -151,4 +151,4 @@ if(VISGUI_ENABLE_GDAL)
   add_definitions(-DVISGUI_USE_GDAL)
 endif()
 
-find_package(geographiclib REQUIRED)
+find_package(GeographicLib REQUIRED)

--- a/Libraries/VgCommon/CMakeLists.txt
+++ b/Libraries/VgCommon/CMakeLists.txt
@@ -42,7 +42,6 @@ set(vgCommonWrapObjects
 
 include_directories(
   ${PROJECT_SOURCE_DIR}
-  ${GeographicLib_INCLUDE_DIRS}
   ${PROJ4_INCLUDE_DIR}
 )
 
@@ -75,7 +74,7 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
-  ${GeographicLib_LIBRARIES}
+  GeographicLib::GeographicLib
   ${PROJ4_LIBRARY}
 )
 


### PR DESCRIPTION
Fix incorrect case of GeographicLib's name in the call to find_package; the old case was partly working because GeographicLib uses the '`<lower>-config.cmake`' naming convention, but proper case for the directory name. As a result, CMake would only be able to find the package when given the full path. Using the correct case allows CMake to find GeographicLib when it is installed to a path that is searched by default (e.g. via distro packages).

Also fix an outdated use of GeographicLib's API, and switch to using imported targets to consume GeographicLib.