### PR TITLE
Fix VXL include directories

### DIFF
--- a/CMake/coredeps.cmake
+++ b/CMake/coredeps.cmake
@@ -109,7 +109,7 @@ endif()
 find_package(VXL REQUIRED)
 
 # DO NOT use UseVXL.cmake; its documentation stuff is broken
-include_directories(SYSTEM ${VXL_VCL_INCLUDE_DIR} ${VXL_CORE_INCLUDE_DIR})
+include_directories(SYSTEM ${VXL_VCL_INCLUDE_DIRS} ${VXL_CORE_INCLUDE_DIRS})
 link_directories(${VXL_LIBRARY_DIR})
 
 if (VISGUI_ENABLE_VIDTK)


### PR DESCRIPTION
Change VXL includes to use the `_INCLUDE_DIRS` variables, rather than the `_INCLUDE_DIR` variables. The latter only include the source directory (when using VXL from a build directory, as opposed to an install directory), which results in being unable to find generated headers.

(It's not immediately clear how this would have ever worked; most likely, something in VXL changed.)