### PR TITLE
Invoke AMC by target name

### DIFF
--- a/Libraries/QtExtensions/CMake/Modules/UseQtExtensions.cmake
+++ b/Libraries/QtExtensions/CMake/Modules/UseQtExtensions.cmake
@@ -14,7 +14,7 @@ function(qte_amc_wrap_ui outvar name)
   set(outfile "${CMAKE_CURRENT_BINARY_DIR}/${name}.h")
   set_source_files_properties(${outfiles} ${outfile} PROPERTIES GENERATED TRUE)
   add_custom_command(OUTPUT ${outfiles} ${outfile}
-    COMMAND ${QTE_AMC_EXECUTABLE} ${outfile} ${infiles}
-    DEPENDS ${QTE_AMC_EXECUTABLE} ${infiles})
+    COMMAND qte-amc ${outfile} ${infiles}
+    DEPENDS qte-amc ${infiles})
   set(${outvar} ${outfiles} ${outfile} PARENT_SCOPE)
 endfunction()

--- a/Libraries/QtExtensions/CMakeLists.txt
+++ b/Libraries/QtExtensions/CMakeLists.txt
@@ -13,11 +13,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_executable(qte-amc Tools/qtActionManagerCompiler.cxx)
 target_link_libraries(qte-amc ${QT_LIBRARIES})
 
-get_property(QTE_AMC_EXECUTABLE TARGET qte-amc PROPERTY LOCATION)
-set(QTE_AMC_EXECUTABLE "${QTE_AMC_EXECUTABLE}"
-    CACHE INTERNAL "Location of the qte-amc executable" FORCE
-)
-
 # END action manager compiler
 
 ###############################################################################


### PR DESCRIPTION
Get rid of the code to get the location of qte-amc (which is deprecated and was causing a CMake warning) and instead invoke it via the target name. The old logic likely dates to before CMake supported doing that...