### PR TITLE
 Port VDF track_oracle plugin to KWIVER

### DIFF
--- a/Plugins/VdfDataSources/CMakeLists.txt
+++ b/Plugins/VdfDataSources/CMakeLists.txt
@@ -1,3 +1,3 @@
-if(VISGUI_ENABLE_VIDTK)
+if(TARGET track_oracle OR TARGET kwiver::track_oracle)
   add_subdirectory(TrackOracleArchiveSource)
 endif()

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/CMakeLists.txt
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/CMakeLists.txt
@@ -5,9 +5,13 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 vg_include_library_sdk_directories(vgDataFramework)
-include_directories(SYSTEM
-  ${VIDTK_INCLUDE_DIRS}
-)
+
+if(TARGET kwiver::track_oracle)
+  include_directories(SYSTEM ${KWIVER_INCLUDE_DIRS})
+  add_definitions(-DKWIVER_TRACK_ORACLE)
+else()
+  include_directories(SYSTEM ${VIDTK_INCLUDE_DIRS})
+endif()
 
 set(vdfTrackOracleArchiveSource_Sources
   vdfTrackOracleArchiveSourcePlugin.cxx
@@ -27,9 +31,19 @@ vg_add_qt_plugin(${PROJECT_NAME}
   ${vdfTrackOracleArchiveSource_MocSources}
 )
 
+if(TARGET kwiver::track_oracle)
+  target_link_libraries(${PROJECT_NAME}
+    kwiver::track_oracle
+    kwiver::track_oracle_file_formats
+  )
+else()
+  target_link_libraries(${PROJECT_NAME}
+    track_oracle
+    track_oracle_file_formats
+  )
+endif()
+
 target_link_libraries(${PROJECT_NAME}
-  track_oracle
-  track_oracle_file_formats
   vgDataFramework
   ${QT_LIBRARIES}
 )

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/track_oracle_file_format_fwd.h
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/track_oracle_file_format_fwd.h
@@ -1,0 +1,34 @@
+/*ckwg +5
+ * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __track_oracle_file_format_fwd_h
+#define __track_oracle_file_format_fwd_h
+
+#ifdef KWIVER_TRACK_ORACLE
+namespace kwiver
+{
+  namespace track_oracle
+  {
+    class file_format_base;
+  }
+}
+#else
+namespace vidtk
+{
+  class file_format_base;
+}
+#endif
+
+namespace track_oracle
+{
+#ifdef KWIVER_TRACK_ORACLE
+  using namespace kwiver::track_oracle;
+#else
+  using namespace vidtk;
+#endif
+}
+
+#endif

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/track_oracle_utils.h
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/track_oracle_utils.h
@@ -1,0 +1,46 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __track_oracle_utils_h
+#define __track_oracle_utils_h
+
+#ifdef KWIVER_TRACK_ORACLE
+namespace kwiver
+{
+  namespace track_oracle
+  {
+    template <typename T> class track_field;
+  }
+}
+#else
+namespace vidtk
+{
+  template <typename T> class track_field;
+}
+#endif
+
+namespace track_oracle
+{
+#ifdef KWIVER_TRACK_ORACLE
+  using namespace kwiver::track_oracle;
+#else
+  using namespace vidtk;
+#endif
+
+  template <typename T>
+  struct track_field_type;
+
+  template <typename T>
+  struct track_field_type<::track_oracle::track_field<T>&>
+  {
+    using type = T;
+  };
+}
+
+#define TRACK_ORACLE_INIT_FIELD(t, n) \
+  n(t.add_field<::track_oracle::track_field_type<decltype(n)>::type>(#n))
+
+#endif

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/vdfTrackOracleTrackArchiveSource.h
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/vdfTrackOracleTrackArchiveSource.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -9,10 +9,7 @@
 
 #include <vdfThreadedArchiveSource.h>
 
-namespace vidtk
-{
-  class file_format_base;
-}
+#include "track_oracle_file_format_fwd.h"
 
 class vdfTrackOracleTrackDataSourcePrivate;
 
@@ -22,7 +19,7 @@ class vdfTrackOracleTrackDataSource : public vdfThreadedArchiveSource
 
 public:
   vdfTrackOracleTrackDataSource(
-    const QUrl& archiveUri, vidtk::file_format_base* format,
+    const QUrl& archiveUri, track_oracle::file_format_base* format,
     QObject* parent = 0);
   virtual ~vdfTrackOracleTrackDataSource();
 

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/visgui_track_type.h
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/visgui_track_type.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,8 +7,15 @@
 #ifndef __visgui_track_type_h
 #define __visgui_track_type_h
 
+#include "track_oracle_utils.h"
+
+#ifdef KWIVER_TRACK_ORACLE
+#include <track_oracle/core/track_base.h>
+#include <track_oracle/core/track_field.h>
+#else
 #include <track_oracle/track_base.h>
 #include <track_oracle/track_field.h>
+#endif
 
 #include <vgl/vgl_box_2d.h>
 #include <vgl/vgl_point_2d.h>
@@ -18,36 +25,43 @@
 
 //-----------------------------------------------------------------------------
 struct visgui_minimal_track_type :
-  public vidtk::track_base<visgui_minimal_track_type>
+  public track_oracle::track_base<visgui_minimal_track_type>
 {
-  vidtk::track_field<unsigned int>& external_id;
+  track_oracle::track_field<unsigned int>& external_id;
 
-  vidtk::track_field<unsigned long long>& timestamp_usecs;
-  vidtk::track_field<vgl_box_2d<double> >& bounding_box;
-  vidtk::track_field<vgl_point_2d<double> >& obj_location;
+  track_oracle::track_field<unsigned long long>& timestamp_usecs;
+  track_oracle::track_field<vgl_box_2d<double> >& bounding_box;
+  track_oracle::track_field<vgl_point_2d<double> >& obj_location;
 
   visgui_minimal_track_type() :
-    external_id(Track.add_field<unsigned int>("external_id")),
-    timestamp_usecs(Frame.add_field<unsigned long long>("timestamp_usecs")),
-    bounding_box(Frame.add_field<vgl_box_2d<double> >("bounding_box")),
-    obj_location(Frame.add_field<vgl_point_2d<double> >("obj_location"))
+    TRACK_ORACLE_INIT_FIELD(Track, external_id),
+
+    TRACK_ORACLE_INIT_FIELD(Frame, timestamp_usecs),
+    TRACK_ORACLE_INIT_FIELD(Frame, bounding_box),
+    TRACK_ORACLE_INIT_FIELD(Frame, obj_location)
     {
     }
 };
 
 //-----------------------------------------------------------------------------
 struct visgui_track_type :
-  public vidtk::track_base<visgui_track_type, visgui_minimal_track_type>
+  public track_oracle::track_base<visgui_track_type, visgui_minimal_track_type>
 {
-  vidtk::track_field<boost::uuids::uuid>& unique_id;
+#ifndef KWIVER_TRACK_ORACLE
+  // TODO: Reenable this when UUID's are supported by KWIVER's track_oracle
+  track_oracle::track_field<boost::uuids::uuid>& unique_id;
+#endif
 
-  vidtk::track_field<unsigned>& frame_number;
-  vidtk::track_field<vgl_point_3d<double> >& world_location;
+  track_oracle::track_field<unsigned>& frame_number;
+  track_oracle::track_field<vgl_point_3d<double> >& world_location;
 
   visgui_track_type() :
-    unique_id(Track.add_field<boost::uuids::uuid>("unique_id")),
-    frame_number(Frame.add_field<unsigned>("frame_number")),
-    world_location(Frame.add_field<vgl_point_3d<double> >("world_location"))
+#ifndef KWIVER_TRACK_ORACLE
+    TRACK_ORACLE_INIT_FIELD(Track, unique_id),
+#endif
+
+    TRACK_ORACLE_INIT_FIELD(Frame, frame_number),
+    TRACK_ORACLE_INIT_FIELD(Frame, world_location)
     {
     }
 };

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/CMakeLists.txt
@@ -42,7 +42,6 @@ else()
   target_link_libraries(${PROJECT_NAME}
     track_oracle
     track_oracle_file_formats
-    ${QT_LIBRARIES}
   )
 endif()
 

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleArchiveSourcePlugin.cxx
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleArchiveSourcePlugin.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -65,11 +65,10 @@ public:
 void vsTrackOracleArchiveSourcePluginPrivate::addSchemas(
   FileFormatMap& map, const track_oracle::track_base_impl& schema)
 {
-  auto formats =
+  const auto& formats =
     track_oracle::file_format_manager::format_matches_schema(schema);
-  for (size_t n = 0, k = formats.size(); n < k; ++n)
+  for (const auto& format : formats)
     {
-    auto const& format = formats[n];
     auto* const format_instance =
       track_oracle::file_format_manager::get_format(format);
     if (format_instance)


### PR DESCRIPTION
Port the vdfDataSources track_oracle plugin to support use of the KWIVER version of track_oracle. This makes it possible to use the plugin with the publicly available version of track_oracle (which is in KWIVER), and is an initial step in making WAMI Viewer useful without VidTK.

In theory, these changes are backwards-compatible, i.e. will still work with the old vidk track_oracle, however UUID support is presently disabled as KWIVER's track_oracle does not currently support it.

This change is analogous to the port of the vspSourceService track_oracle plugin (#6).