### PR TITLE
Refactor vpProject; add non-VidTK parser

### DIFF
--- a/Applications/VpView/vpFseTrackIO.cxx
+++ b/Applications/VpView/vpFseTrackIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -242,29 +242,7 @@ bool vpFseTrackIO::ImportTracks(vtkIdType idsOffset,
         points.clear();
         }
 
-      if (this->HasOverrideColor)
-        {
-        track->SetColor(this->OverrideColor);
-        }
-      else
-        {
-        double color[3];
-        int typeIndex = track->GetType();
-        if (typeIndex != -1)
-          {
-          // If the track has a valid type, use that to look up a color
-          const vgTrackType& type = this->TrackTypes->GetType(typeIndex);
-          type.GetColor(color[0], color[1], color[2]);
-          track->SetColor(color[0], color[1], color[2]);
-          }
-        else
-          {
-          this->GetDefaultTrackColor(track->GetId(), color);
-          track->SetColor(color);
-          }
-        }
-      this->TrackModel->AddTrack(track);
-      track->FastDelete();
+      this->AddTrack(track);
       }
     }
   catch (...)

--- a/Applications/VpView/vpModelIO.cxx
+++ b/Applications/VpView/vpModelIO.cxx
@@ -16,7 +16,7 @@ vpModelIO::vpModelIO() :
 {}
 
 //-----------------------------------------------------------------------------
-void vpModelIO::SetTrackOverrideColor(double color[3])
+void vpModelIO::SetTrackOverrideColor(const vgColor& color)
 {
   assert(this->TrackIO);
   this->TrackIO->SetOverrideColor(color);

--- a/Applications/VpView/vpModelIO.h
+++ b/Applications/VpView/vpModelIO.h
@@ -38,7 +38,7 @@ public:
   virtual void SetImageHeight(unsigned int imageHeight) = 0;
   virtual unsigned int GetImageHeight() const = 0;
 
-  void SetTrackOverrideColor(double color[3]);
+  void SetTrackOverrideColor(const vgColor&);
 
   virtual bool ReadFrameMetaData(vpFrameMap* frameMap,
                                  const std::string& substitutePath);

--- a/Applications/VpView/vpProject.cxx
+++ b/Applications/VpView/vpProject.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -21,87 +21,11 @@
 
 //-----------------------------------------------------------------------------
 vpProject::vpProject(int id) :
-  OverviewFileTag("OverviewFile"),
-  DataSetSpecifierTag("DataSetSpecifier"),
-  TracksFileTag("TracksFile"),
-  TrackTraitsFileTag("TrackTraitsFile"),
-  EventsFileTag("EventsFile"),
-  EventLinksFileTag("EventLinksFile"),
-  IconsFileTag("IconsFile"),
-  ActivitiesFileTag("ActivitiesFile"),
-  InformaticsIconFileTag("InformaticsIconFile"),
-  NormalcyMapsFileTag("NormalcyMapsFile"),
-  PrecomputeActivityTag("PrecomputeActivity"),
-  OverviewSpacingTag("OverviewSpacing"),
-  OverviewOriginTag("OverviewOrigin"),
-  AnalysisDimensionsTag("AnalysisDimensions"),
-  AOIUpperLeftLatLonTag("AOIUpperLeftLatLon"),
-  AOIUpperRightLatLonTag("AOIUpperRightLatLon"),
-  AOILowerLeftLatLonTag("AOILowerLeftLatLon"),
-  AOILowerRightLatLonTag("AOILowerRightLatLon"),
-  ColorWindowTag("ColorWindow"),
-  ColorLevelTag("ColorLevel"),
-  ColorMultiplierTag("ColorMultiplier"),
-  TrackColorOverrideTag("TrackColorOverride"),
-  FrameNumberOffsetTag("FrameNumberOffset"),
-  ImageTimeMapFileTag("ImageTimeMapFile"),
-  HomographyIndexFileTag("HomographyIndexFile"),
-  FiltersFileTag("FiltersFile"),
-  SceneElementsFileTag("SceneElementsFile"),
-  ImageToGcsMatrixTag("ImageToGcsMatrix"),
+  TagFileMap{BuildTagFileMap(this)},
   ProjectId(id),
   NextCreateTrackId(3000000),
   IsVisible(true)
 {
-  // Internal storage. This is useful as we are going to iterate over the filenames.
-  TagFileMap.insert(
-    std::make_pair(this->OverviewFileTag, &this->OverviewFile));
-  TagFileMap.insert(
-    std::make_pair(this->DataSetSpecifierTag, &this->DataSetSpecifier));
-  TagFileMap.insert(
-    std::make_pair(this->TracksFileTag, &this->TracksFile));
-  TagFileMap.insert(
-    std::make_pair(this->TrackTraitsFileTag, &this->TrackTraitsFile));
-  TagFileMap.insert(
-    std::make_pair(this->EventsFileTag, &this->EventsFile));
-  TagFileMap.insert(
-    std::make_pair(this->EventLinksFileTag, &this->EventLinksFile));
-  TagFileMap.insert(
-    std::make_pair(this->IconsFileTag, &this->IconsFile));
-  TagFileMap.insert(
-    std::make_pair(this->ActivitiesFileTag, &this->ActivitiesFile));
-  TagFileMap.insert(
-    std::make_pair(this->InformaticsIconFileTag, &this->InformaticsIconFile));
-  TagFileMap.insert(
-    std::make_pair(this->NormalcyMapsFileTag, &this->NormalcyMapsFile));
-  TagFileMap.insert(
-    std::make_pair(this->ImageTimeMapFileTag, &this->ImageTimeMapFile));
-  TagFileMap.insert(
-    std::make_pair(this->HomographyIndexFileTag, &this->HomographyIndexFile));
-  TagFileMap.insert(
-    std::make_pair(this->FiltersFileTag, &this->FiltersFile));
-  TagFileMap.insert(
-    std::make_pair(this->SceneElementsFileTag, &this->SceneElementsFile));
-
-  this->PrecomputeActivity = 0;
-
-  this->OverviewSpacing = 1.0;
-  this->OverviewOrigin[0] = this->OverviewOrigin[1] = 0.0;
-  this->AnalysisDimensions[0] = this->AnalysisDimensions[1] = 0.0;
-
-  this->AOIUpperLeftLatLon[0] = this->AOIUpperLeftLatLon[1] = 444;
-  this->AOIUpperRightLatLon[0] = this->AOIUpperRightLatLon[1] = 444;
-  this->AOILowerLeftLatLon[0] = this->AOILowerLeftLatLon[1] = 444;
-  this->AOILowerRightLatLon[0] = this->AOILowerRightLatLon[1] = 444;
-
-  this->ColorWindow = 255.0;
-  this->ColorLevel = 127.5;
-
-  this->ColorMultiplier = 1.0;
-  this->HasTrackColorOverride = false;
-
-  this->FrameNumberOffset = 0;
-
   this->TrackModel = vtkSmartPointer<vtkVpTrackModel>::New();
   this->TrackRepresentation = vtkSmartPointer<vtkVgTrackRepresentation>::New();
   this->SelectedTrackRepresentation =
@@ -138,80 +62,55 @@ vpProject::~vpProject()
 }
 
 //-----------------------------------------------------------------------------
-void vpProject::SetIsValid(const std::string& file, int state)
+QHash<QString, QString*> vpProject::BuildTagFileMap(vpProjectBase* base)
 {
-  if (!file.empty())
+  QHash<QString, QString*> map;
+
+#define ADD_MAPPING(x) map.insert(x##Tag, &base->x)
+  ADD_MAPPING(OverviewFile);
+  ADD_MAPPING(DataSetSpecifier);
+  ADD_MAPPING(TracksFile);
+  ADD_MAPPING(TrackTraitsFile);
+  ADD_MAPPING(EventsFile);
+  ADD_MAPPING(EventLinksFile);
+  ADD_MAPPING(IconsFile);
+  ADD_MAPPING(ActivitiesFile);
+  ADD_MAPPING(InformaticsIconFile);
+  ADD_MAPPING(NormalcyMapsFile);
+  ADD_MAPPING(ImageTimeMapFile);
+  ADD_MAPPING(HomographyIndexFile);
+  ADD_MAPPING(FiltersFile);
+  ADD_MAPPING(SceneElementsFile);
+#undef ADD_MAPPING
+
+  return map;
+}
+
+//-----------------------------------------------------------------------------
+void vpProject::SetIsValid(const QString& file, FileState state)
+{
+  if (!file.isEmpty())
     {
     this->FileValidityMap[file] = state;
     }
 }
 
 //-----------------------------------------------------------------------------
-int vpProject::IsValid(const std::string& file)
+vpProject::FileState vpProject::IsValid(const QString& file)
 {
-  if (file.empty())
+  if (file.isEmpty())
     {
     return FILE_NAME_EMPTY;
     }
 
-  vpProject::FileValidityMapConstItr itr = this->FileValidityMap.find(file);
-  if (itr != this->FileValidityMap.end())
-    {
-    return itr->second;
-    }
-
-  return FILE_NAME_NOT_EMPTY;
+  return this->FileValidityMap.value(file, FILE_NAME_NOT_EMPTY);
 }
 
 
 //-----------------------------------------------------------------------------
 void vpProject::CopyConfig(const vpProject& srcProject)
 {
-  this->ConfigFileStem = srcProject.ConfigFileStem;
-  this->OverviewFile = srcProject.ConfigFileStem;
-  this->DataSetSpecifier = srcProject.DataSetSpecifier;
-  this->TracksFile = srcProject.TracksFile;
-  this->TrackTraitsFile = srcProject.TrackTraitsFile;
-  this->EventsFile = srcProject.EventsFile;
-  this->EventLinksFile = srcProject.EventLinksFile;
-  this->IconsFile = srcProject.IconsFile;
-  this->ActivitiesFile = srcProject.ActivitiesFile;
-  this->InformaticsIconFile = srcProject.InformaticsIconFile;
-  this->NormalcyMapsFile = srcProject.NormalcyMapsFile;
-  this->ImageTimeMapFile = srcProject.ImageTimeMapFile;
-  this->HomographyIndexFile = srcProject.HomographyIndexFile;
-  this->FiltersFile = srcProject.FiltersFile;
-  this->SceneElementsFile = srcProject.SceneElementsFile;
+  vpProjectBase::operator=(srcProject);
 
-  this->PrecomputeActivity = srcProject.PrecomputeActivity;
-
-  this->OverviewSpacing = srcProject.OverviewSpacing;
-  this->OverviewOrigin[0] = srcProject.OverviewOrigin[0];
-  this->OverviewOrigin[1] = srcProject.OverviewOrigin[1];
-
-  this->ColorWindow = srcProject.ColorWindow;
-  this->ColorLevel = srcProject.ColorLevel;
-
-  this->ColorMultiplier = srcProject.ColorMultiplier;
-  this->FrameNumberOffset = srcProject.FrameNumberOffset;
-
-  this->HasTrackColorOverride = srcProject.HasTrackColorOverride;
-  this->TrackColorOverride[0] = srcProject.TrackColorOverride[0];
-  this->TrackColorOverride[1] = srcProject.TrackColorOverride[1];
-  this->TrackColorOverride[2] = srcProject.TrackColorOverride[2];
-
-  this->AOIUpperLeftLatLon[0] = srcProject.AOIUpperLeftLatLon[0];
-  this->AOIUpperLeftLatLon[1] = srcProject.AOIUpperLeftLatLon[1];
-  this->AOIUpperRightLatLon[0] = srcProject.AOIUpperRightLatLon[0];
-  this->AOIUpperRightLatLon[1] = srcProject.AOIUpperRightLatLon[1];
-  this->AOILowerLeftLatLon[0] = srcProject.AOILowerLeftLatLon[0];
-  this->AOILowerLeftLatLon[1] = srcProject.AOILowerLeftLatLon[1];
-  this->AOILowerRightLatLon[0] = srcProject.AOILowerRightLatLon[0];
-  this->AOILowerRightLatLon[1] = srcProject.AOILowerRightLatLon[1];
-
-  this->AnalysisDimensions[0] = srcProject.AnalysisDimensions[0];
-  this->AnalysisDimensions[1] = srcProject.AnalysisDimensions[1];
-
-  this->TagFileMap = srcProject.TagFileMap;
   this->FileValidityMap = srcProject.FileValidityMap;
 }

--- a/Applications/VpView/vpProject.h
+++ b/Applications/VpView/vpProject.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,9 +7,14 @@
 #ifndef __vpProject_h
 #define __vpProject_h
 
-#include <QSharedPointer>
+#include "vpProjectBase.h"
+
+#include <qtGlobal.h>
 
 #include <vtkSmartPointer.h>
+
+#include <QHash>
+#include <QSharedPointer>
 
 #include <string>
 #include <map>
@@ -33,7 +38,7 @@ class vtkVgTrackRepresentation;
 class vtkVpReaderBase;
 class vtkVpTrackModel;
 
-class vpProject
+class vpProject : public vpProjectBase
 {
 public:
   enum FileState
@@ -51,100 +56,56 @@ public:
 
   // Description:
   // Set if a file is valid (if it exists on the system).
-  void SetIsValid(const std::string& file, int state);
+  void SetIsValid(const QString& file, FileState state);
 
   // Description:
   // Check if a given file is valid or not.
-  int IsValid(const std::string& file);
+  FileState IsValid(const QString& file);
 
   void CopyConfig(const vpProject& srcProject);
 
-  // Description:
-  // Keep track of file path stem for finding other files
-  std::string ConfigFileStem;
+#define PROJECT_FIELD_TAG(x) static constexpr const char* x##Tag = #x
+  PROJECT_FIELD_TAG(OverviewFile);
+  PROJECT_FIELD_TAG(DataSetSpecifier);
+  PROJECT_FIELD_TAG(TracksFile);
+  PROJECT_FIELD_TAG(TrackTraitsFile);
+  PROJECT_FIELD_TAG(EventsFile);
+  PROJECT_FIELD_TAG(EventLinksFile);
+  PROJECT_FIELD_TAG(IconsFile);
+  PROJECT_FIELD_TAG(ActivitiesFile);
+  PROJECT_FIELD_TAG(InformaticsIconFile);
+  PROJECT_FIELD_TAG(NormalcyMapsFile);
+  PROJECT_FIELD_TAG(PrecomputeActivity);
 
-  // Description:
-  // Various file sources used for the data.
-  std::string OverviewFile;
-  std::string DataSetSpecifier;
-  std::string TracksFile;
-  std::string TrackTraitsFile;
-  std::string EventsFile;
-  std::string EventLinksFile;
-  std::string IconsFile;
-  std::string ActivitiesFile;
-  std::string InformaticsIconFile;
-  std::string NormalcyMapsFile;
-  std::string ImageTimeMapFile;
-  std::string HomographyIndexFile;
-  std::string FiltersFile;
-  std::string SceneElementsFile;
+  PROJECT_FIELD_TAG(OverviewSpacing);
+  PROJECT_FIELD_TAG(OverviewOrigin);
+  PROJECT_FIELD_TAG(AnalysisDimensions);
 
-  std::string OverviewFileTag;
-  std::string DataSetSpecifierTag;
-  std::string TracksFileTag;
-  std::string TrackTraitsFileTag;
-  std::string EventsFileTag;
-  std::string EventLinksFileTag;
-  std::string IconsFileTag;
-  std::string ActivitiesFileTag;
-  std::string InformaticsIconFileTag;
-  std::string NormalcyMapsFileTag;
-  std::string PrecomputeActivityTag;
+  PROJECT_FIELD_TAG(AOI);
+  PROJECT_FIELD_TAG(AOIUpperLeftLatLon); // DEPRECATED (vidtk reader only)
+  PROJECT_FIELD_TAG(AOIUpperRightLatLon); // DEPRECATED (vidtk reader only)
+  PROJECT_FIELD_TAG(AOILowerLeftLatLon); // DEPRECATED (vidtk reader only)
+  PROJECT_FIELD_TAG(AOILowerRightLatLon); // DEPRECATED (vidtk reader only)
 
-  std::string OverviewSpacingTag;
-  std::string OverviewOriginTag;
-  std::string AnalysisDimensionsTag;
+  PROJECT_FIELD_TAG(ColorWindow);
+  PROJECT_FIELD_TAG(ColorLevel);
 
-  std::string AOIUpperLeftLatLonTag;
-  std::string AOIUpperRightLatLonTag;
-  std::string AOILowerLeftLatLonTag;
-  std::string AOILowerRightLatLonTag;
+  PROJECT_FIELD_TAG(ColorMultiplier);
+  PROJECT_FIELD_TAG(TrackColorOverride);
 
-  std::string ColorWindowTag;
-  std::string ColorLevelTag;
+  PROJECT_FIELD_TAG(FrameNumberOffset);
+  PROJECT_FIELD_TAG(ImageTimeMapFile);
+  PROJECT_FIELD_TAG(HomographyIndexFile);
 
-  std::string ColorMultiplierTag;
-  std::string TrackColorOverrideTag;
+  PROJECT_FIELD_TAG(FiltersFile);
+  PROJECT_FIELD_TAG(SceneElementsFile);
 
-  std::string FrameNumberOffsetTag;
-  std::string ImageTimeMapFileTag;
-  std::string HomographyIndexFileTag;
+  PROJECT_FIELD_TAG(ImageToGcsMatrix);
+#undef PROJECT_FIELD_TAG
 
-  std::string FiltersFileTag;
-  std::string SceneElementsFileTag;
+  const QHash<QString, QString*> TagFileMap;
 
-  std::string ImageToGcsMatrixTag;
-
-  int    PrecomputeActivity;
-
-  double OverviewSpacing;
-  double OverviewOrigin [2];
-
-  double AOIUpperLeftLatLon[2];
-  double AOIUpperRightLatLon[2];
-  double AOILowerLeftLatLon[2];
-  double AOILowerRightLatLon[2];
-
-  double AnalysisDimensions[2];
-
-  double ColorWindow;
-  double ColorLevel;
-
-  double ColorMultiplier;
-
-  bool HasTrackColorOverride;
-  double TrackColorOverride[3];
-
-  int FrameNumberOffset;
-
-  // Description:
-  // Useful data structure.
-  std::map<std::string, std::string*> TagFileMap;
-  typedef std::map<std::string, std::string*>::const_iterator TagFileMapItr;
-
-  std::map<std::string, int> FileValidityMap;
-  typedef std::map<std::string, int>::const_iterator FileValidityMapConstItr;
+  QHash<QString, FileState> FileValidityMap;
 
   // Description:
   // Project specific models and representations
@@ -169,7 +130,6 @@ public:
 
   // Description:
   // Project specific transformation matrices
-  double ImageToGcsMatrixArray[18];
   vtkSmartPointer<vtkMatrix4x4> ImageToGcsMatrix;
 
   // Description:
@@ -182,11 +142,13 @@ public:
 
   bool IsVisible;
 
-  std::string Name;
+  QString Name;
+
+protected:
+  static QHash<QString, QString*> BuildTagFileMap(vpProjectBase* base);
 
 private:
-  vpProject(const vpProject& src);        // Not implemented.
-  void operator=(const vpProject& src);   // Not implemented.
+  QTE_DISABLE_COPY(vpProject);
 };
 
-#endif // __vpProject_h
+#endif

--- a/Applications/VpView/vpProjectBase.h
+++ b/Applications/VpView/vpProjectBase.h
@@ -11,15 +11,12 @@
 
 #include <vgGeoTypes.h>
 
-#include <QDir>
 #include <QPointF>
 #include <QSizeF>
 #include <QString>
 
 struct vpProjectBase
 {
-  QDir ConfigFileStem;
-
   QString OverviewFile;
   QString DataSetSpecifier;
   QString TracksFile;

--- a/Applications/VpView/vpProjectBase.h
+++ b/Applications/VpView/vpProjectBase.h
@@ -1,0 +1,56 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __vpProjectBase_h
+#define __vpProjectBase_h
+
+#include <vgColor.h>
+
+#include <vgGeoTypes.h>
+
+#include <QDir>
+#include <QPointF>
+#include <QSizeF>
+#include <QString>
+
+struct vpProjectBase
+{
+  QDir ConfigFileStem;
+
+  QString OverviewFile;
+  QString DataSetSpecifier;
+  QString TracksFile;
+  QString TrackTraitsFile;
+  QString EventsFile;
+  QString EventLinksFile;
+  QString IconsFile;
+  QString ActivitiesFile;
+  QString InformaticsIconFile;
+  QString NormalcyMapsFile;
+  QString ImageTimeMapFile;
+  QString HomographyIndexFile;
+  QString FiltersFile;
+  QString SceneElementsFile;
+
+  int PrecomputeActivity = 0;
+
+  double OverviewSpacing = 1.0;
+  QPointF OverviewOrigin = {0.0, 0.0};
+
+  vgGeocodedTile AOI;
+  QSizeF AnalysisDimensions;
+
+  double ColorWindow = 255.0;
+  double ColorLevel = 127.5;
+
+  double ColorMultiplier = 1.0;
+
+  vgColor TrackColorOverride;
+
+  int FrameNumberOffset = 0;
+};
+
+#endif

--- a/Applications/VpView/vpProjectParser.cxx
+++ b/Applications/VpView/vpProjectParser.cxx
@@ -84,6 +84,7 @@ bool vpProjectParser::Parse(vpProject* prj)
   vidtk::config_block_parser blkParser;
   std::istringstream iss;
 
+  QDir projectDir;
   if (this->UseStream)
     {
     iss.str(stdString(this->ProjectStream));
@@ -92,8 +93,7 @@ bool vpProjectParser::Parse(vpProject* prj)
   else
     {
     blkParser.set_filename(stdString(this->ProjectFileName));
-    prj->ConfigFileStem =
-      QDir{QFileInfo{this->ProjectFileName}.canonicalPath()};
+    projectDir = QDir{QFileInfo{this->ProjectFileName}.canonicalPath()};
     }
 
   // \note: Exception is thrown by the parser if a unknown tag is found
@@ -122,7 +122,7 @@ bool vpProjectParser::Parse(vpProject* prj)
     filePath = qtString(vidtk::token_expansion::expand_token(value));
     if (!filePath.isEmpty())
       {
-      filePath = prj->ConfigFileStem.absoluteFilePath(filePath);
+      filePath = projectDir.absoluteFilePath(filePath);
       }
 
     if (tag == prj->DataSetSpecifierTag ||

--- a/Applications/VpView/vpProjectParser.cxx
+++ b/Applications/VpView/vpProjectParser.cxx
@@ -6,27 +6,24 @@
 
 #include "vpProjectParser.h"
 
-// Application includes.
-#include "vpProject.h"
+#include "vgGeodesy.h"
 
-// qtExtensions includes.
+#include <qtEnumerate.h>
 #include <qtStlUtil.h>
 
-// VIDTK includes.
 #ifdef VISGUI_USE_VIDTK
 #include <utilities/config_block.h>
 #include <utilities/config_block_parser.h>
 #include <utilities/token_expansion.h>
 #endif
 
-// VTK includes.
 #include <vtkMatrix4x4.h>
 #include <vtksys/SystemTools.hxx>
 
-// Qt includes.
 #include <QDebug>
+#include <QDir>
+#include <QFileInfo>
 
-// C++ includes.
 #include <exception>
 #include <iomanip>
 #include <sstream>
@@ -89,15 +86,14 @@ bool vpProjectParser::Parse(vpProject* prj)
 
   if (this->UseStream)
     {
-    iss.str(this->ProjectStream);
+    iss.str(stdString(this->ProjectStream));
     blkParser.set_input_stream(iss);
     }
   else
     {
-    blkParser.set_filename(this->ProjectFileName);
+    blkParser.set_filename(stdString(this->ProjectFileName));
     prj->ConfigFileStem =
-      this->ProjectFileName.substr(0, this->ProjectFileName.find_last_of("/\\"));
-    prj->ConfigFileStem = prj->ConfigFileStem.append("/");
+      QDir{QFileInfo{this->ProjectFileName}.canonicalPath()};
     }
 
   // \note: Exception is thrown by the parser if a unknown tag is found
@@ -117,114 +113,143 @@ bool vpProjectParser::Parse(vpProject* prj)
     }
 
   // Various file sources used for the data.
-  vpProject::TagFileMapItr bItr = prj->TagFileMap.begin();
-  while (bItr != prj->TagFileMap.end())
+  foreach (const auto& fileTag, qtEnumerate(prj->TagFileMap))
     {
-    *bItr->second = blk.get<std::string>(bItr->first);
+    const auto& tag = fileTag.key();
+    auto& filePath = *(fileTag.value());
 
-    *bItr->second = vidtk::token_expansion::expand_token(*bItr->second);
-
-    this->ConstructCompletePath(*bItr->second, prj->ConfigFileStem);
-
-    if (bItr->first == prj->DataSetSpecifierTag ||
-        bItr->first == prj->TracksFileTag)
+    const auto& value = blk.get<std::string>(stdString(tag));
+    filePath = qtString(vidtk::token_expansion::expand_token(value));
+    if (!filePath.isEmpty())
       {
-      prj->SetIsValid(*bItr->second, (*bItr->second).empty() ?
-                      vpProject::FILE_NAME_EMPTY : vpProject::FILE_NAME_NOT_EMPTY);
+      filePath = prj->ConfigFileStem.absoluteFilePath(filePath);
+      }
+
+    if (tag == prj->DataSetSpecifierTag ||
+        tag == prj->TracksFileTag)
+      {
+      const auto expectedState =
+        (filePath.isEmpty() ? vpProject::FILE_NAME_EMPTY
+                            : vpProject::FILE_NAME_NOT_EMPTY);
+      prj->SetIsValid(filePath, expectedState);
       }
     else
       {
-      prj->SetIsValid(*bItr->second,
-                      this->CheckIfFileExists(bItr->first, *bItr->second));
+      const auto expectedState =
+        this->CheckIfFileExists(tag, filePath);
+      prj->SetIsValid(filePath, expectedState);
       }
-
-    ++bItr;
     }
 
+  // Read non-string fields that can be read directly
   prj->PrecomputeActivity = blk.get<int>(prj->PrecomputeActivityTag);
   prj->OverviewSpacing = blk.get<double>(prj->OverviewSpacingTag);
   prj->ColorWindow = blk.get<double>(prj->ColorWindowTag);
   prj->ColorLevel = blk.get<double>(prj->ColorLevelTag);
   prj->ColorMultiplier = blk.get<double>(prj->ColorMultiplierTag);
   prj->FrameNumberOffset = blk.get<double>(prj->FrameNumberOffsetTag);
-  blk.get(prj->OverviewOriginTag,      prj->OverviewOrigin);
-  blk.get(prj->AnalysisDimensionsTag,  prj->AnalysisDimensions);
-  blk.get(prj->AOIUpperLeftLatLonTag,  prj->AOIUpperLeftLatLon);
-  blk.get(prj->AOIUpperRightLatLonTag, prj->AOIUpperRightLatLon);
-  blk.get(prj->AOILowerLeftLatLonTag, prj->AOILowerLeftLatLon);
-  blk.get(prj->AOILowerRightLatLonTag, prj->AOILowerRightLatLon);
 
+  // Read various fields that consist of two numbers
+  double pt[2];
+
+  blk.get(prj->OverviewOriginTag, pt);
+  prj->OverviewOrigin = {pt[0], pt[1]};
+
+  blk.get(prj->AnalysisDimensionsTag, pt);
+  prj->AnalysisDimensions = {pt[0], pt[1]};
+
+  prj->AOI.GCS = vgGeodesy::LatLon_Wgs84;
+  const char* aoiTags[4] = {
+    prj->AOIUpperLeftLatLonTag,
+    prj->AOIUpperRightLatLonTag,
+    prj->AOILowerRightLatLonTag,
+    prj->AOILowerLeftLatLonTag};
+  for (int i = 0; i < 4; ++i)
+    {
+    blk.get(aoiTags[i], pt);
+    if (fabs(pt[0]) > 360.0 || fabs(pt[1]) > 360.0)
+      {
+      prj->AOI.GCS = -1;
+      break;
+      }
+    prj->AOI.Coordinate[i] = {pt[0], pt[1]};
+    }
+
+  // Read track override color
+  double oc[3];
   try
     {
-    blk.get(prj->TrackColorOverrideTag, prj->TrackColorOverride);
-    prj->HasTrackColorOverride = true;
+    blk.get(prj->TrackColorOverrideTag, oc);
+    prj->TrackColorOverride = vgColor{oc[0], oc[1], oc[2]};
     }
   catch (...) {}
 
+  // Read image-to-GCS matrix
+  double i2gMatrix[18];
   try
     {
-    blk.get(prj->ImageToGcsMatrixTag,  prj->ImageToGcsMatrixArray);
+    blk.get(prj->ImageToGcsMatrixTag,  i2gMatrix);
     prj->ImageToGcsMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
 
     // Get the number of rows and columns
-    int noOfRows = prj->ImageToGcsMatrixArray[0];
-    int noOfCols = prj->ImageToGcsMatrixArray[1];
+    int noOfRows = i2gMatrix[0];
+    int noOfCols = i2gMatrix[1];
 
     // 3x3
     if (noOfRows == 3 && noOfCols == 3)
       {
-      prj->ImageToGcsMatrix->SetElement(0, 0, prj->ImageToGcsMatrixArray[2]);
-      prj->ImageToGcsMatrix->SetElement(0, 1, prj->ImageToGcsMatrixArray[3]);
-      prj->ImageToGcsMatrix->SetElement(0, 3, prj->ImageToGcsMatrixArray[4]);
+      prj->ImageToGcsMatrix->SetElement(0, 0, i2gMatrix[2]);
+      prj->ImageToGcsMatrix->SetElement(0, 1, i2gMatrix[3]);
+      prj->ImageToGcsMatrix->SetElement(0, 3, i2gMatrix[4]);
 
-      prj->ImageToGcsMatrix->SetElement(1, 0, prj->ImageToGcsMatrixArray[5]);
-      prj->ImageToGcsMatrix->SetElement(1, 1, prj->ImageToGcsMatrixArray[6]);
-      prj->ImageToGcsMatrix->SetElement(1, 3, prj->ImageToGcsMatrixArray[7]);
+      prj->ImageToGcsMatrix->SetElement(1, 0, i2gMatrix[5]);
+      prj->ImageToGcsMatrix->SetElement(1, 1, i2gMatrix[6]);
+      prj->ImageToGcsMatrix->SetElement(1, 3, i2gMatrix[7]);
 
-      prj->ImageToGcsMatrix->SetElement(3, 0, prj->ImageToGcsMatrixArray[8]);
-      prj->ImageToGcsMatrix->SetElement(3, 1, prj->ImageToGcsMatrixArray[9]);
-      prj->ImageToGcsMatrix->SetElement(3, 3, prj->ImageToGcsMatrixArray[10]);
+      prj->ImageToGcsMatrix->SetElement(3, 0, i2gMatrix[8]);
+      prj->ImageToGcsMatrix->SetElement(3, 1, i2gMatrix[9]);
+      prj->ImageToGcsMatrix->SetElement(3, 3, i2gMatrix[10]);
       }
     // 3X4
     else if (noOfRows == 3 && noOfCols == 4)
       {
-      prj->ImageToGcsMatrix->SetElement(0, 0, prj->ImageToGcsMatrixArray[2]);
-      prj->ImageToGcsMatrix->SetElement(0, 1, prj->ImageToGcsMatrixArray[3]);
-      prj->ImageToGcsMatrix->SetElement(0, 2, prj->ImageToGcsMatrixArray[4]);
-      prj->ImageToGcsMatrix->SetElement(0, 3, prj->ImageToGcsMatrixArray[5]);
+      prj->ImageToGcsMatrix->SetElement(0, 0, i2gMatrix[2]);
+      prj->ImageToGcsMatrix->SetElement(0, 1, i2gMatrix[3]);
+      prj->ImageToGcsMatrix->SetElement(0, 2, i2gMatrix[4]);
+      prj->ImageToGcsMatrix->SetElement(0, 3, i2gMatrix[5]);
 
-      prj->ImageToGcsMatrix->SetElement(1, 0, prj->ImageToGcsMatrixArray[6]);
-      prj->ImageToGcsMatrix->SetElement(1, 1, prj->ImageToGcsMatrixArray[7]);
-      prj->ImageToGcsMatrix->SetElement(1, 2, prj->ImageToGcsMatrixArray[8]);
-      prj->ImageToGcsMatrix->SetElement(1, 3, prj->ImageToGcsMatrixArray[9]);
+      prj->ImageToGcsMatrix->SetElement(1, 0, i2gMatrix[6]);
+      prj->ImageToGcsMatrix->SetElement(1, 1, i2gMatrix[7]);
+      prj->ImageToGcsMatrix->SetElement(1, 2, i2gMatrix[8]);
+      prj->ImageToGcsMatrix->SetElement(1, 3, i2gMatrix[9]);
 
-      prj->ImageToGcsMatrix->SetElement(3, 0, prj->ImageToGcsMatrixArray[10]);
-      prj->ImageToGcsMatrix->SetElement(3, 1, prj->ImageToGcsMatrixArray[11]);
-      prj->ImageToGcsMatrix->SetElement(3, 2, prj->ImageToGcsMatrixArray[12]);
-      prj->ImageToGcsMatrix->SetElement(3, 3, prj->ImageToGcsMatrixArray[13]);
+      prj->ImageToGcsMatrix->SetElement(3, 0, i2gMatrix[10]);
+      prj->ImageToGcsMatrix->SetElement(3, 1, i2gMatrix[11]);
+      prj->ImageToGcsMatrix->SetElement(3, 2, i2gMatrix[12]);
+      prj->ImageToGcsMatrix->SetElement(3, 3, i2gMatrix[13]);
       }
     //4x3
     else if (noOfRows == 4 && noOfCols == 3)
       {
-      prj->ImageToGcsMatrix->SetElement(0, 0, prj->ImageToGcsMatrixArray[2]);
-      prj->ImageToGcsMatrix->SetElement(0, 1, prj->ImageToGcsMatrixArray[3]);
-      prj->ImageToGcsMatrix->SetElement(0, 3, prj->ImageToGcsMatrixArray[4]);
+      prj->ImageToGcsMatrix->SetElement(0, 0, i2gMatrix[2]);
+      prj->ImageToGcsMatrix->SetElement(0, 1, i2gMatrix[3]);
+      prj->ImageToGcsMatrix->SetElement(0, 3, i2gMatrix[4]);
 
-      prj->ImageToGcsMatrix->SetElement(1, 0, prj->ImageToGcsMatrixArray[5]);
-      prj->ImageToGcsMatrix->SetElement(1, 1, prj->ImageToGcsMatrixArray[6]);
-      prj->ImageToGcsMatrix->SetElement(1, 3, prj->ImageToGcsMatrixArray[7]);
+      prj->ImageToGcsMatrix->SetElement(1, 0, i2gMatrix[5]);
+      prj->ImageToGcsMatrix->SetElement(1, 1, i2gMatrix[6]);
+      prj->ImageToGcsMatrix->SetElement(1, 3, i2gMatrix[7]);
 
-      prj->ImageToGcsMatrix->SetElement(2, 0, prj->ImageToGcsMatrixArray[8]);
-      prj->ImageToGcsMatrix->SetElement(2, 1, prj->ImageToGcsMatrixArray[9]);
-      prj->ImageToGcsMatrix->SetElement(2, 3, prj->ImageToGcsMatrixArray[10]);
+      prj->ImageToGcsMatrix->SetElement(2, 0, i2gMatrix[8]);
+      prj->ImageToGcsMatrix->SetElement(2, 1, i2gMatrix[9]);
+      prj->ImageToGcsMatrix->SetElement(2, 3, i2gMatrix[10]);
 
-      prj->ImageToGcsMatrix->SetElement(3, 0, prj->ImageToGcsMatrixArray[11]);
-      prj->ImageToGcsMatrix->SetElement(3, 1, prj->ImageToGcsMatrixArray[12]);
-      prj->ImageToGcsMatrix->SetElement(3, 3, prj->ImageToGcsMatrixArray[13]);
+      prj->ImageToGcsMatrix->SetElement(3, 0, i2gMatrix[11]);
+      prj->ImageToGcsMatrix->SetElement(3, 1, i2gMatrix[12]);
+      prj->ImageToGcsMatrix->SetElement(3, 3, i2gMatrix[13]);
       }
     else if(noOfRows == 4 && noOfCols ==4)
       {
-        prj->ImageToGcsMatrix->DeepCopy(&prj->ImageToGcsMatrixArray[2]);
+        prj->ImageToGcsMatrix->DeepCopy(&i2gMatrix[2]);
       }
     else
       {
@@ -242,36 +267,17 @@ bool vpProjectParser::Parse(vpProject* prj)
 }
 
 //-----------------------------------------------------------------------------
-void vpProjectParser::ConstructCompletePath(std::string& file, const std::string& stem)
+vpProject::FileState vpProjectParser::CheckIfFileExists(
+  const QString& tag, const QString& fileName)
 {
-  // First remove carriage return.
-  std::string::size_type pos = std::string::npos;
-
-  pos = file.rfind('\r', pos);
-
-  if (pos != std::string::npos)
-    {
-    file.erase(pos, 1);
-    }
-
-  if (!file.empty() &&
-      !vtksys::SystemTools::FileIsFullPath(file.c_str()))
-    {
-    file = stem + file;
-    }
-}
-
-//-----------------------------------------------------------------------------
-int vpProjectParser::CheckIfFileExists(const std::string& tag, const std::string& fileName)
-{
-  if (fileName.empty())
+  if (fileName.isEmpty())
     {
     return vpProject::FILE_NAME_EMPTY;
     }
 
-  if (!vtksys::SystemTools::FileExists(fileName.c_str(), true))
+  if (!QFileInfo{fileName}.exists())
     {
-    qWarning() << "WARNING:" << tag.c_str() << '(' << qtString(fileName) << ')'
+    qWarning() << "WARNING:" << tag << '(' << fileName << ')'
                << "does not exist; application may not work properly";
 
     return vpProject::FILE_NOT_EXIST;

--- a/Applications/VpView/vpProjectParser.cxx
+++ b/Applications/VpView/vpProjectParser.cxx
@@ -9,6 +9,7 @@
 #include "vgGeodesy.h"
 
 #include <qtEnumerate.h>
+#include <qtKstReader.h>
 #include <qtStlUtil.h>
 
 #ifdef VISGUI_USE_VIDTK
@@ -23,10 +24,105 @@
 #include <QDebug>
 #include <QDir>
 #include <QFileInfo>
+#include <QSettings>
+#include <QTemporaryFile>
 
 #include <exception>
 #include <iomanip>
 #include <sstream>
+
+namespace
+{
+
+//-----------------------------------------------------------------------------
+template <typename T>
+bool readValue(const QSettings& reader, const QString& key, T& value)
+{
+  const QVariant& var = reader.value(key, QVariant::fromValue(value));
+  if (var.isValid())
+    {
+    if (var.canConvert<T>())
+      {
+      value = var.value<T>();
+      return true;
+      }
+    qWarning() << "WARNING:" << key << "has invalid value" << var;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+template <>
+bool readValue(const QSettings& reader, const QString& key, QPointF& value)
+{
+  const QVariant& var = reader.value(key);
+  if (var.isValid())
+    {
+    const auto& l = var.toList();
+    if (l.size() == 2)
+      {
+      bool xOkay = true, yOkay = true;
+      const auto x = l[0].toReal(&xOkay);
+      const auto y = l[1].toReal(&yOkay);
+      if (xOkay && yOkay)
+        {
+        value = {x, y};
+        return true;
+        }
+      }
+    qWarning() << "WARNING:" << key << "has invalid value" << var;
+    }
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+template <>
+bool readValue(const QSettings& reader, const QString& key, QSizeF& value)
+{
+  const QVariant& var = reader.value(key);
+  if (var.isValid())
+    {
+    const auto& l = var.toList();
+    if (l.size() == 2)
+      {
+      bool widthOkay = true, heightOkay = true;
+      const auto width = l[0].toReal(&widthOkay);
+      const auto height = l[1].toReal(&heightOkay);
+      if (widthOkay && heightOkay)
+        {
+        value = {width, height};
+        return true;
+        }
+      }
+    qWarning() << "WARNING:" << key << "has invalid value" << var;
+    }
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+template <>
+bool readValue(const QSettings& reader, const QString& key,
+               vgGeoRawCoordinate& value)
+{
+  const QVariant& var = reader.value(key);
+  if (var.isValid())
+    {
+    const auto& l = var.toStringList();
+
+    qtKstReader parser{QString{"[%1];"}.arg(l.join(","))};
+    QList<double> values;
+    if (parser.readRealArray(values) && values.size() == 2)
+      {
+      value = {values[0], values[1]};
+      return true;
+      }
+    qWarning() << "WARNING:" << key << "has invalid value" << var;
+    }
+  return false;
+}
+
+} // namespace <anonymous>
 
 //-----------------------------------------------------------------------------
 vpProjectParser::vpProjectParser() :
@@ -261,8 +357,94 @@ bool vpProjectParser::Parse(vpProject* prj)
 
   return true;
 #else // VISGUI_USE_VIDTK
-  // TODO: Write a non-vidtk based project parser.
-  return false;
+  QScopedPointer<QTemporaryFile> streamFile;
+  QString projectFileName;
+  QDir projectDir;
+
+  if (this->UseStream)
+    {
+    streamFile.reset(new QTemporaryFile);
+    if (!streamFile->open())
+      {
+      qWarning() << "Failed to create temporary file for project stream";
+      return false;
+      }
+
+    streamFile->write(this->ProjectStream.data(), this->ProjectStream.size());
+    projectFileName = streamFile->fileName();
+    }
+  else
+    {
+    projectFileName = this->ProjectFileName;
+    projectDir = QDir{QFileInfo{projectFileName}.canonicalPath()};
+    }
+
+  QSettings reader{projectFileName, QSettings::IniFormat};
+
+  // Read file path fields
+  foreach (const auto& fileTag, qtEnumerate(prj->TagFileMap))
+    {
+    const auto& tag = fileTag.key();
+    auto& filePath = *(fileTag.value());
+
+    // TODO implement token expansion? (Use from KWIVER if available?)
+    filePath = reader.value(tag).toString();
+    if (!filePath.isEmpty())
+      {
+      filePath = projectDir.absoluteFilePath(filePath);
+      }
+
+    if (tag == prj->DataSetSpecifierTag ||
+        tag == prj->TracksFileTag)
+      {
+      const auto expectedState =
+        (filePath.isEmpty() ? vpProject::FILE_NAME_EMPTY
+                            : vpProject::FILE_NAME_NOT_EMPTY);
+      prj->SetIsValid(filePath, expectedState);
+      }
+    else
+      {
+      const auto expectedState =
+        this->CheckIfFileExists(tag, filePath);
+      prj->SetIsValid(filePath, expectedState);
+      }
+    }
+
+  // Read non-string fields
+  readValue(reader, prj->PrecomputeActivityTag, prj->PrecomputeActivity);
+  readValue(reader, prj->OverviewSpacingTag,    prj->OverviewSpacing);
+  readValue(reader, prj->ColorWindowTag,        prj->ColorWindow);
+  readValue(reader, prj->ColorLevelTag,         prj->ColorLevel);
+  readValue(reader, prj->ColorMultiplierTag,    prj->ColorMultiplier);
+  readValue(reader, prj->FrameNumberOffsetTag,  prj->FrameNumberOffset);
+  readValue(reader, prj->OverviewOriginTag,     prj->OverviewOrigin);
+  readValue(reader, prj->AnalysisDimensionsTag, prj->AnalysisDimensions);
+
+  // Read track override color
+  prj->TrackColorOverride.read(reader, prj->TrackColorOverrideTag);
+
+  // Read AOI
+  reader.beginGroup("AOI");
+  if (readValue(reader, "TopLeft", prj->AOI.Coordinate[0]))
+    {
+    readValue(reader, "GCS", prj->AOI.GCS = vgGeodesy::LatLon_Wgs84);
+
+    prj->AOI.Coordinate[2] = prj->AOI.Coordinate[0];
+    readValue(reader, "BottomRight", prj->AOI.Coordinate[2]);
+
+    prj->AOI.Coordinate[1].Easting  = prj->AOI.Coordinate[2].Easting;
+    prj->AOI.Coordinate[1].Northing = prj->AOI.Coordinate[0].Northing;
+    prj->AOI.Coordinate[3].Easting  = prj->AOI.Coordinate[0].Easting;
+    prj->AOI.Coordinate[3].Northing = prj->AOI.Coordinate[2].Northing;
+    readValue(reader, "TopRight", prj->AOI.Coordinate[1]);
+    readValue(reader, "BottomLeft", prj->AOI.Coordinate[3]);
+    }
+  reader.endGroup();
+
+  // Read image-to-GCS matrix
+  // TODO
+
+  return true;
 #endif
 }
 

--- a/Applications/VpView/vpProjectParser.h
+++ b/Applications/VpView/vpProjectParser.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,13 +7,13 @@
 #ifndef __vpProjectParser_h
 #define __vpProjectParser_h
 
-// C++ includes.
-#include <string>
+#include "vpProject.h"
+
+#include <qtStlUtil.h>
 
 #include <vtkSetGet.h>
 
-// Forward declarations.
-class vpProject;
+#include <string>
 
 class vpProjectParser
 {
@@ -38,20 +38,24 @@ public:
   // Description:
   // Set/Get name of the configuration file that needs
   // to be parsed.
-  void SetFileName(const std::string& fileName)
+  void SetFileName(const QString& fileName)
     {
     this->ProjectFileName = fileName;
     }
-  const std::string& GetProjectFileName() const
+  const QString& GetProjectFileName() const
     {
     return this->ProjectFileName;
     }
 
   // Description:
   // Set/Get stream to use for configuration.
-  void SetStream(const std::string& stream)
+  void SetStream(const QByteArray& stream)
     {
     this->ProjectStream = stream;
+    }
+  void SetStream(const std::string& stream)
+    {
+    this->ProjectStream = qtBytes(stream);
     }
 
   // Description:
@@ -59,14 +63,13 @@ public:
   bool Parse(vpProject* prj);
 
 private:
-  void ConstructCompletePath(std::string& fileName, const std::string& stem);
-
-  int  CheckIfFileExists(const std::string& tag, const std::string& fileName);
+  static vpProject::FileState CheckIfFileExists(
+    const QString& tag, const QString& fileName);
 
   bool UseStream;
 
-  std::string        ProjectFileName;
-  std::string        ProjectStream;
+  QString    ProjectFileName;
+  QByteArray ProjectStream;
 };
 
 #endif // __vpProjectParser_h

--- a/Applications/VpView/vpQtViewer3d.cxx
+++ b/Applications/VpView/vpQtViewer3d.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -734,10 +734,10 @@ void vpQtViewer3d::updateContext(const vtkVgTimeStamp& timestamp)
     {
     this->Internal->ContextSource.TakeReference(
       vpImageSourceFactory::GetInstance()->Create(nextDataFile));
-    this->Internal->ContextSource->SetOrigin(this->Project->OverviewOrigin[0],
-                                             this->Project->OverviewOrigin[1],
+    this->Internal->ContextSource->SetOrigin(this->Project->OverviewOrigin.x(),
+                                             this->Project->OverviewOrigin.y(),
                                              0.0);
-    if (this->Project->OverviewSpacing != -1)
+    if (this->Project->OverviewSpacing >= 0.0)
       {
       this->Internal->ContextSource->SetSpacing(this->Project->OverviewSpacing,
                                                 this->Project->OverviewSpacing,
@@ -792,11 +792,11 @@ void vpQtViewer3d::updateContext(const vtkVgTimeStamp& timestamp)
 
       if (i < 2)
         {
-        readExtents[i] -= this->Project->OverviewOrigin[0];
+        readExtents[i] -= this->Project->OverviewOrigin.x();
         }
       else
         {
-        readExtents[i] -= this->Project->OverviewOrigin[1];
+        readExtents[i] -= this->Project->OverviewOrigin.y();
         }
       }
 

--- a/Applications/VpView/vpTrackIO.cxx
+++ b/Applications/VpView/vpTrackIO.cxx
@@ -6,6 +6,8 @@
 
 #include "vpTrackIO.h"
 
+#include "vtkVpTrackModel.h"
+
 #include <vtkVgTrackModel.h>
 #include <vtkVgTrackTypeRegistry.h>
 
@@ -109,4 +111,32 @@ void vpTrackIO::GetDefaultTrackColor(int trackId, double (&color)[3])
   color[0] = DefaultTrackColors[colorIdx][0] / 255.0;
   color[1] = DefaultTrackColors[colorIdx][1] / 255.0;
   color[2] = DefaultTrackColors[colorIdx][2] / 255.0;
+}
+
+//-----------------------------------------------------------------------------
+void vpTrackIO::AddTrack(vtkVgTrack* track)
+{
+  if (this->HasOverrideColor)
+    {
+    track->SetColor(this->OverrideColor);
+    }
+  else
+    {
+    double color[3];
+    int typeIndex = track->GetType();
+    if (typeIndex != -1)
+      {
+      // If the track has a valid type, use that to look up a color
+      const vgTrackType& type = this->TrackTypes->GetType(typeIndex);
+      type.GetColor(color[0], color[1], color[2]);
+      track->SetColor(color[0], color[1], color[2]);
+      }
+    else
+      {
+      this->GetDefaultTrackColor(track->GetId(), color);
+      track->SetColor(color);
+      }
+    }
+  this->TrackModel->AddTrack(track);
+  track->FastDelete();
 }

--- a/Applications/VpView/vpTrackIO.h
+++ b/Applications/VpView/vpTrackIO.h
@@ -7,6 +7,8 @@
 #ifndef __vpTrackIO_h
 #define __vpTrackIO_h
 
+#include <vgColor.h>
+
 #include <vtkSmartPointer.h>
 
 class vpFrameMap;
@@ -54,7 +56,7 @@ public:
 
   virtual ~vpTrackIO();
 
-  void SetOverrideColor(const double color[3]);
+  void SetOverrideColor(const vgColor&);
 
   virtual bool ReadTracks() = 0;
   virtual bool ReadTrackTraits();
@@ -91,8 +93,7 @@ protected:
   TrackTimeStampMode TimeStampMode;
   vtkSmartPointer<vtkMatrix4x4> GeoTransform;
   vpFrameMap* FrameMap;
-  double OverrideColor[3];
-  bool HasOverrideColor;
+  vgColor OverrideColor;
 };
 
 #endif // __vpTrackIO_h

--- a/Applications/VpView/vpTrackIO.h
+++ b/Applications/VpView/vpTrackIO.h
@@ -82,6 +82,8 @@ protected:
 protected:
   friend class vpFileTrackIOImpl;
 
+  void AddTrack(vtkVgTrack*);
+
   vtkVpTrackModel* TrackModel;
   vtkVgTrackTypeRegistry* TrackTypes;
 

--- a/Applications/VpView/vpVidtkTrackIO.cxx
+++ b/Applications/VpView/vpVidtkTrackIO.cxx
@@ -941,29 +941,7 @@ void vpVidtkTrackIO::ReadTrack(
 
   if (newTrack)
     {
-    if (this->HasOverrideColor)
-      {
-      track->SetColor(this->OverrideColor);
-      }
-    else
-      {
-      double color[3];
-      int typeIndex = track->GetType();
-      if (typeIndex != -1)
-        {
-        // If the track has a valid type, use that to look up a color
-        const vgTrackType& type = this->TrackTypes->GetType(typeIndex);
-        type.GetColor(color[0], color[1], color[2]);
-        track->SetColor(color[0], color[1], color[2]);
-        }
-      else
-        {
-        this->GetDefaultTrackColor(track->GetId(), color);
-        track->SetColor(color);
-        }
-      }
-    this->TrackModel->AddTrack(track);
-    track->FastDelete();
+    this->AddTrack(track);
     }
 
   this->TrackMap[track] = vidtkTrack;

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -7,8 +7,8 @@
 #include "vpViewCore.h"
 
 #include <vgActivityType.h>
-#include <vgColor.h>
 #include <vgEventType.h>
+#include <vgGeodesy.h>
 #include <vgTrackType.h>
 #include <vgFileDialog.h>
 #include <vgMixerWidget.h>
@@ -181,12 +181,25 @@
 
 #include <GeographicLib/Geodesic.hpp>
 
+namespace
+{
+
 static double TrackEditColor[] = { 1.0, .274, .274 };
 static double SelectedColor[] =  { 1.0, 0.08, 0.58 };
 
 enum { DefaultTrackExpiration = 10 };
 
 enum RegionEditMode { REM_Auto, REM_BoundingBox, REM_Polygon };
+
+//-----------------------------------------------------------------------------
+vgGeocodedCoordinate getCorner(
+  const vgGeocodedTile& tile, size_t corner, int gcs)
+{
+  const auto c = vgGeocodedCoordinate{tile.Coordinate[corner], tile.GCS};
+  return vgGeodesy::convertGcs(c, gcs);
+}
+
+} // namespace <anonymous>
 
 // Workaround name collision with macro from WinUser.h
 #undef GetProp
@@ -368,8 +381,7 @@ void vpViewCore::importProject()
   QScopedPointer<vpProject> project(new vpProject(this->CurrentProjectId + 1));
   this->ProjectParser->Parse(project.data());
 
-  if (project->AnalysisDimensions[0] == -1.0 ||
-      project->AnalysisDimensions[1] == -1.0)
+  if (!project->AnalysisDimensions.isValid())
     {
     emit this->warningError("The source project does not have valid AOI "
                             "dimensions specified in the project file. "
@@ -380,8 +392,7 @@ void vpViewCore::importProject()
 
   if (this->UseRawImageCoordinates)
     {
-    if (project->AOIUpperLeftLatLon[0] == 444.0 ||
-        project->AOIUpperLeftLatLon[1] == 444.0)
+    if (project->AOI.GCS < 0)
       {
       emit this->warningError("The source project does not have valid AOI "
                               "geocoordinates. It cannot be imported while in "
@@ -391,7 +402,7 @@ void vpViewCore::importProject()
     }
 
   if (QDir::cleanPath(qtString(this->ImageDataSource->getDataSetSpecifier())) !=
-      QDir::cleanPath(qtString(project->DataSetSpecifier)))
+      QDir::cleanPath(project->DataSetSpecifier))
     {
     if (QMessageBox::warning(0, QString(),
                              "The project to be imported has a different "
@@ -424,17 +435,17 @@ void vpViewCore::importProject()
     }
 
   // Point current project's IO manager to the files we are importing from.
-  currentIO->SetTracksFileName(project->TracksFile.c_str());
-  currentIO->SetTrackTraitsFileName(project->TrackTraitsFile.c_str());
-  currentIO->SetEventsFileName(project->EventsFile.c_str());
-  currentIO->SetEventLinksFileName(project->EventLinksFile.c_str());
-  currentIO->SetActivitiesFileName(project->ActivitiesFile.c_str());
-  currentIO->SetFseTracksFileName(project->SceneElementsFile.c_str());
+  currentIO->SetTracksFileName(qPrintable(project->TracksFile));
+  currentIO->SetTrackTraitsFileName(qPrintable(project->TrackTraitsFile));
+  currentIO->SetEventsFileName(qPrintable(project->EventsFile));
+  currentIO->SetEventLinksFileName(qPrintable(project->EventLinksFile));
+  currentIO->SetActivitiesFileName(qPrintable(project->ActivitiesFile));
+  currentIO->SetFseTracksFileName(qPrintable(project->SceneElementsFile));
 
   // Temporarily change the AOI height to that of the input project, so that
   // imported object points get y-flipped correctly.
-  SetImageHeight sih(currentIO,
-                     static_cast<unsigned int>(project->AnalysisDimensions[1]));
+  SetImageHeight sih{
+    currentIO, static_cast<unsigned int>(project->AnalysisDimensions.height())};
 
   // Compute the offsets needed to transform the track data to the AOI of the
   // current project.
@@ -443,8 +454,8 @@ void vpViewCore::importProject()
   if (this->UseRawImageCoordinates)
     {
     // Compute the image coordinates of the AOI origin for the source project.
-    double point[4] = { project->AOIUpperLeftLatLon[1],
-                        project->AOIUpperLeftLatLon[0], 0.0, 1.0 };
+    const auto& aoiUL = getCorner(project->AOI, 0, vgGeodesy::LatLon_Wgs84);
+    double point[4] = { aoiUL.Easting, aoiUL.Northing, 0.0, 1.0 };
     this->LatLonToImageReferenceMatrix->MultiplyPoint(point, point);
     if (point[3] != 0)
       {
@@ -459,10 +470,10 @@ void vpViewCore::importProject()
   else if (!this->UseGeoCoordinates)
     {
     // Using inverted image coordinates.
-    offsetX = static_cast<float>(currentProject->OverviewOrigin[0] -
-                                 project->OverviewOrigin[0]);
-    offsetY = static_cast<float>(currentProject->OverviewOrigin[1] -
-                                 project->OverviewOrigin[1]);
+    offsetX = static_cast<float>(currentProject->OverviewOrigin.x() -
+                                 project->OverviewOrigin.x());
+    offsetY = static_cast<float>(currentProject->OverviewOrigin.y() -
+                                 project->OverviewOrigin.y());
     }
   else
     {
@@ -546,8 +557,8 @@ bool vpViewCore::importTracksFromFile(vpProject* project)
       {
       const QString msgFormat =
         "Failed to load tracks from file/pattern \"%1\" (for %2)";
-      emit this->warningError(msgFormat.arg(qtString(project->TracksFile),
-                                            qtString(project->TracksFileTag)));
+      emit this->warningError(msgFormat.arg(project->TracksFile,
+                                            QString{project->TracksFileTag}));
       }
 
     // load track traits file if one was given
@@ -703,7 +714,7 @@ bool vpViewCore::importOverviewFromFile(vpProject* project)
   if (project->IsValid(project->OverviewFile) == vpProject::FILE_EXIST)
     {
     const int levelOfDetailToLoad = 3;
-    this->ImageSource->SetFileName(project->OverviewFile.c_str());
+    this->ImageSource->SetFileName(qPrintable(project->OverviewFile));
     this->ImageSource->SetLevel(levelOfDetailToLoad);
     this->ImageSource->Update();
     this->ImageData[0]->DeepCopy(this->ImageSource->GetOutput());
@@ -726,8 +737,8 @@ bool vpViewCore::importOverviewFromFile(vpProject* project)
       this->ImageData[0]->SetSpacing(
         1 << levelOfDetailToLoad, 1 << levelOfDetailToLoad, 1);
       }
-    this->ImageData[0]->SetOrigin(project->OverviewOrigin[0],
-                                  project->OverviewOrigin[1],
+    this->ImageData[0]->SetOrigin(project->OverviewOrigin.x(),
+                                  project->OverviewOrigin.y(),
                                   0);
     this->emit overviewLoaded();
     }
@@ -744,8 +755,7 @@ bool vpViewCore::importNormalcyMapsFromFile(vpProject* project)
 {
   if (project->IsValid(project->NormalcyMapsFile) == vpProject::FILE_EXIST)
     {
-    return this->NormalcyMaps->LoadFromFile(
-             qtString(project->NormalcyMapsFile));
+    return this->NormalcyMaps->LoadFromFile(project->NormalcyMapsFile);
     }
 
   return false;
@@ -1288,7 +1298,7 @@ int vpViewCore::loadIcons(vpProject* project)
   msgBox.setModal(false);
   msgBox.show();
 
-  if (project->IconManager->LoadIcons(project->IconsFile.c_str()) != VTK_OK)
+  if (project->IconManager->LoadIcons(qPrintable(project->IconsFile)) != VTK_OK)
     {
     return VTK_ERROR;
     }
@@ -2811,12 +2821,12 @@ vpProject* vpViewCore::loadProject(const char* fileName)
 
 #ifdef VISGUI_USE_VIDTK
   QSharedPointer<vpVidtkFileIO> fileIO(new vpVidtkFileIO);
-  fileIO->SetTracksFileName(project->TracksFile.c_str());
-  fileIO->SetTrackTraitsFileName(project->TrackTraitsFile.c_str());
-  fileIO->SetEventsFileName(project->EventsFile.c_str());
-  fileIO->SetEventLinksFileName(project->EventLinksFile.c_str());
-  fileIO->SetActivitiesFileName(project->ActivitiesFile.c_str());
-  fileIO->SetFseTracksFileName(project->SceneElementsFile.c_str());
+  fileIO->SetTracksFileName(qPrintable(project->TracksFile));
+  fileIO->SetTrackTraitsFileName(qPrintable(project->TrackTraitsFile));
+  fileIO->SetEventsFileName(qPrintable(project->EventsFile));
+  fileIO->SetEventLinksFileName(qPrintable(project->EventLinksFile));
+  fileIO->SetActivitiesFileName(qPrintable(project->ActivitiesFile));
+  fileIO->SetFseTracksFileName(qPrintable(project->SceneElementsFile));
   project->ModelIO = fileIO;
   return this->processProject(project);
 #else
@@ -2835,7 +2845,7 @@ vpProject* vpViewCore::loadProject(const QSharedPointer<vpModelIO>& modelIO,
   this->ProjectParser->SetUseStream(true);
 
   // Not really a filename, but this string will be used in the UI as a label
-  this->ProjectParser->SetFileName(name);
+  this->ProjectParser->SetFileName(qtString(name));
 
   QScopedPointer<vpProject> project(new vpProject(this->CurrentProjectId++));
   this->ProjectParser->Parse(project.data());
@@ -2866,41 +2876,39 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
       }
 
     // Allow user to change the data path if not found
+    const auto dataSet = QFileInfo{project->DataSetSpecifier};
+    const auto& path = dataSet.path();
     std::string substitutePath;
-    size_t pos = project->DataSetSpecifier.find_last_of("/\\");
-    if (pos != std::string::npos)
+    if (!QDir{path}.exists())
       {
-      QString path = qtString(project->DataSetSpecifier.substr(0, pos));
-      if (!QDir(path).exists())
+      if (QMessageBox::warning(
+            0, QString(),
+            QString{"\"%1\" doesn't appear to be a valid path. Would you "
+                    "like to change the base path for project image data?"}
+                    .arg(path), QMessageBox::Yes | QMessageBox::Cancel) ==
+          QMessageBox::Yes)
         {
-        if (QMessageBox::warning(
-              0, QString(),
-              QString("%1\n\ndoesn't appear to be a valid path. Would you "
-                      "like to change the base path for project image data?")
-                      .arg(path), QMessageBox::Ok | QMessageBox::Cancel) ==
-            QMessageBox::Ok)
+        for (;;)
           {
-          for (;;)
+          auto newPath =
+            QInputDialog::getText(0, QString(), "Path:", QLineEdit::Normal,
+                                  path);
+
+          if (newPath.isEmpty())
             {
-            QString newPath =
-              QInputDialog::getText(0, QString(), "Path:", QLineEdit::Normal,
-                                    path);
+            break;
+            }
 
-            if (newPath.isEmpty())
-              {
-              break;
-              }
-
-            if (!QDir(newPath).exists())
-              {
-              QMessageBox::warning(0, QString(), "Path does not exist.");
-              }
-            else
-              {
-              substitutePath = stdString(newPath);
-              project->DataSetSpecifier.replace(0, pos, substitutePath);
-              break;
-              }
+          if (!QDir{newPath}.exists())
+            {
+            QMessageBox::warning(0, QString(), "Path does not exist.");
+            }
+          else
+            {
+            substitutePath = stdString(newPath);
+            project->DataSetSpecifier =
+              QDir{newPath}.filePath(dataSet.fileName());
+            break;
             }
           }
         }
@@ -2937,7 +2945,8 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
 
     if (!hasFrameMap)
       {
-      this->ImageDataSource->setDataSetSpecifier(project->DataSetSpecifier);
+      this->ImageDataSource->setDataSetSpecifier(
+        stdString(project->DataSetSpecifier));
 
       this->NumberOfFrames =
         static_cast<unsigned int>(this->ImageDataSource->getFileCount());
@@ -2958,7 +2967,7 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
         case vpProject::FILE_EXIST:
           {
           // Populate the image->time map from text file if available.
-          std::ifstream file(project->ImageTimeMapFile.c_str());
+          std::ifstream file(stdString(project->ImageTimeMapFile));
           if (!file.is_open())
             {
             emit this->warningError("Unable to open image time map file.");
@@ -2988,7 +2997,7 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
         case vpProject::FILE_EXIST:
           {
           // Populate the image->time map from text file if available.
-          std::ifstream file(project->HomographyIndexFile.c_str());
+          std::ifstream file(stdString(project->HomographyIndexFile));
           if (!file.is_open())
             {
             emit this->warningError("Unable to open Homography index file.");
@@ -3063,8 +3072,8 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
     // find a strategy about it.
 
     // This needs to set regardless.
-    this->ImageSource->SetOrigin(project->OverviewOrigin[0],
-                                 project->OverviewOrigin[1], 0.0);
+    this->ImageSource->SetOrigin(project->OverviewOrigin.x(),
+                                 project->OverviewOrigin.y(), 0.0);
 
     this->ImageSource->SetFileName(
       this->ImageDataSource->getDataFile(
@@ -3123,9 +3132,7 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
         this->TrackStorageMode = vpTrackIO::TSM_TransformedGeoCoords;
         }
       }
-    else if (this->EnableTranslateImage &&
-             project->AOIUpperLeftLatLon[0] != 444 &&
-             project->AOIUpperLeftLatLon[1] != 444 &&
+    else if (this->EnableTranslateImage && project->AOI.GCS > 0 &&
              this->ImageSource->GetGeoCornerPoints())
       {
       // if both the AOI is specified in lat/lon AND there are lat/lon corner
@@ -3160,10 +3167,10 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
       // the reference offset
       if (this->ImageTranslationReferenceLatLon[0] == 444)
         {
-        this->ImageTranslationReferenceLatLon[0] =
-          project->AOIUpperLeftLatLon[0];
-        this->ImageTranslationReferenceLatLon[1] =
-          project->AOIUpperLeftLatLon[1];
+        const auto& aoiUL =
+          getCorner(project->AOI, 0, vgGeodesy::LatLon_Wgs84);
+        this->ImageTranslationReferenceLatLon[0] = aoiUL.Easting;
+        this->ImageTranslationReferenceLatLon[1] = aoiUL.Northing;
         double in[4] = {this->ImageTranslationReferenceLatLon[1],
                         this->ImageTranslationReferenceLatLon[0], 0, 1.0};
         double out[4];
@@ -3215,17 +3222,17 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
       }
     else
       {
-      this->WholeImageBounds[0] = project->OverviewOrigin[0];
+      this->WholeImageBounds[0] = project->OverviewOrigin.x();
       this->WholeImageBounds[1] = this->WholeImageBounds[0] + dim[0] - 1;
-      this->WholeImageBounds[2] = project->OverviewOrigin[1];
+      this->WholeImageBounds[2] = project->OverviewOrigin.y();
       this->WholeImageBounds[3] = this->WholeImageBounds[2] + dim[1] - 1;
 
       int aoiExtents[4] =
         {
-        static_cast<int>(-project->OverviewOrigin[0]),
-        static_cast<int>(-project->OverviewOrigin[0] + project->AnalysisDimensions[0] - 1),
-        static_cast<int>(-project->OverviewOrigin[1]),
-        static_cast<int>(-project->OverviewOrigin[1] + project->AnalysisDimensions[1] - 1)
+        static_cast<int>(-project->OverviewOrigin.x()),
+        static_cast<int>(-project->OverviewOrigin.x() + project->AnalysisDimensions.width() - 1),
+        static_cast<int>(-project->OverviewOrigin.y()),
+        static_cast<int>(-project->OverviewOrigin.y() + project->AnalysisDimensions.height() - 1)
         };
 
       this->ImageSource->SetReadExtents(aoiExtents);
@@ -3236,15 +3243,11 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
       this->ViewExtents[2] = this->WholeImageBounds[2];
       this->ViewExtents[3] = this->WholeImageBounds[3];
 
-      if (project->AnalysisDimensions[0] == -1)
+      if (!project->AnalysisDimensions.isValid())
         {
-        project->AnalysisDimensions[0] =
-          this->ViewExtents[1] - this->ViewExtents[0] + 1;
-        }
-      if (project->AnalysisDimensions[1] == -1)
-        {
-        project->AnalysisDimensions[1] =
-          this->ViewExtents[3] - this->ViewExtents[2] + 1;
+        project->AnalysisDimensions = {
+          this->ViewExtents[1] - this->ViewExtents[0] + 1,
+          this->ViewExtents[3] - this->ViewExtents[2] + 1};
         }
       }
 
@@ -3273,20 +3276,21 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
     }
   else
     {
-    if (QDir::cleanPath(qtString(this->ImageDataSource->getDataSetSpecifier()))
-        != QDir::cleanPath(qtString(project->DataSetSpecifier)))
+    const auto& dataSet =
+      qtString(this->ImageDataSource->getDataSetSpecifier());
+    if (QDir::cleanPath(dataSet) != QDir::cleanPath(project->DataSetSpecifier))
       {
       QString str = "Warning: \"%1\" has a dataset specifier that doesn't match"
                     " the currently loaded data.";
-      emit warningError(str.arg(QFileInfo(qtString(
-        this->ProjectParser->GetProjectFileName())).fileName()));
+      emit warningError(str.arg(QFileInfo{
+        this->ProjectParser->GetProjectFileName()}.fileName()));
       }
     if (project->FrameNumberOffset != this->FrameNumberOffset)
       {
       QString str = "Warning: \"%1\" has a frame number offset that doesn't match"
                     " the currently loaded data.";
-      emit warningError(str.arg(QFileInfo(qtString(
-        this->ProjectParser->GetProjectFileName())).fileName()));
+      emit warningError(str.arg(QFileInfo{
+        this->ProjectParser->GetProjectFileName()}.fileName()));
       }
     }
 
@@ -3437,10 +3441,10 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
   // We only support a single AOI at the moment (that of the original project).
   // If the project being loaded is not the first and doesn't have explicit AOI
   // dimensions in the project file, AnalysisDimensions will be -1 here anyways.
-  unsigned int imageHeight =
-    static_cast<unsigned int>(this->Projects.empty()
-                                ? project->AnalysisDimensions[1]
-                                : this->Projects[0]->AnalysisDimensions[1]);
+  const auto imageHeightF =
+    (this->Projects.empty() ? project->AnalysisDimensions.height()
+                            : this->Projects[0]->AnalysisDimensions.height());
+  const auto imageHeight = static_cast<unsigned int>(imageHeightF);
 
   project->ModelIO->SetImageHeight(imageHeight);
 
@@ -3472,10 +3476,7 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
     project->Picker->SetImageActor(this->ImageActor[0]);
     }
 
-  if (project->HasTrackColorOverride)
-    {
-    project->ModelIO->SetTrackOverrideColor(project->TrackColorOverride);
-    }
+  project->ModelIO->SetTrackOverrideColor(project->TrackColorOverride);
 
   bool tracksImportSuccessful =
     this->importTracksFromFile(project.data());
@@ -3509,24 +3510,24 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
   vpProject* projPtr = project.take();
   this->Projects.push_back(projPtr);
 
-  if (projPtr->Name.empty())
+  if (projPtr->Name.isEmpty())
     {
-    QFileInfo fi(qtString(this->ProjectParser->GetProjectFileName()));
-    projPtr->Name = stdString(fi.fileName());
+    QFileInfo fi{this->ProjectParser->GetProjectFileName()};
+    projPtr->Name = fi.fileName();
     }
   this->SessionView->AddSession(this, projPtr->ActivityManager,
                                 projPtr->EventModel, projPtr->TrackModel,
                                 this->EventFilter, this->TrackFilter,
                                 this->EventTypeRegistry,
                                 this->TrackTypeRegistry,
-                                projPtr->Name.c_str());
+                                projPtr->Name);
 
 
 
   // Load bundled filters
   if (projPtr->IsValid(projPtr->FiltersFile) == vpProject::FILE_EXIST)
     {
-    this->loadFilters(projPtr->FiltersFile.c_str());
+    this->loadFilters(qPrintable(projPtr->FiltersFile));
     }
 
   // Prevent the interactor from rendering the window before we have performed
@@ -3633,7 +3634,7 @@ void vpViewCore::writeSpatialFilter(
   else
     {
     // Normal inverted-y coord mode, just unflip the filter points
-    double maxY = this->Projects[0]->AnalysisDimensions[1] - 1;
+    double maxY = this->Projects[0]->AnalysisDimensions.height() - 1.0;
     for (vtkIdType i = 0, npts = filterPoints->GetNumberOfPoints(); i < npts;
          ++i)
       {
@@ -3941,12 +3942,12 @@ void vpViewCore::exportForWeb(const char* path, int paddingFrames)
   int currentExtents[4];
   int aoiExtents[4] =
     {
-    static_cast<int>(-this->Projects[0]->OverviewOrigin[0]),
-    static_cast<int>(-this->Projects[0]->OverviewOrigin[0] +
-                     this->Projects[0]->AnalysisDimensions[0] - 1),
-    static_cast<int>(-this->Projects[0]->OverviewOrigin[1]),
-    static_cast<int>(-this->Projects[0]->OverviewOrigin[1] +
-                     this->Projects[0]->AnalysisDimensions[1] - 1)
+    static_cast<int>(-this->Projects[0]->OverviewOrigin.x()),
+    static_cast<int>(-this->Projects[0]->OverviewOrigin.x() +
+                     this->Projects[0]->AnalysisDimensions.width() - 1),
+    static_cast<int>(-this->Projects[0]->OverviewOrigin.y()),
+    static_cast<int>(-this->Projects[0]->OverviewOrigin.y() +
+                     this->Projects[0]->AnalysisDimensions.height() - 1)
     };
 
   this->ImageSource->GetReadExtents(currentExtents);
@@ -4182,8 +4183,8 @@ again:
       points->GetPoint(id, point);
 
       // TODO: Transform world-based points
-      point[0] -= project->OverviewOrigin[0];
-      point[1] -= project->OverviewOrigin[1];
+      point[0] -= project->OverviewOrigin.x();
+      point[1] -= project->OverviewOrigin.y();
 
       // compute the cropped region of the image
       int extents[6];
@@ -4237,8 +4238,8 @@ again:
             {
             double point[3];
             points->GetPoint(ptIds[i], point);
-            point[0] -= project->OverviewOrigin[0];
-            point[1] -= project->OverviewOrigin[1];
+            point[0] -= project->OverviewOrigin.x();
+            point[1] -= project->OverviewOrigin.y();
             bbox.AddPoint(point);
             }
 
@@ -4647,12 +4648,13 @@ CreateInformaticsDisplay(int vtkNotUsed(x), int vtkNotUsed(y), vtkImageData* vtk
 {
   if (!this->Projects[0]->IsValid(this->Projects[0]->InformaticsIconFile))
     {
-    std::cerr << "ERROR: File ( " << this->Projects[0]->InformaticsIconFile
-              << " ) does not exist or is invalid." << std::endl;
+    qWarning() << "ERROR: File" << this->Projects[0]->InformaticsIconFile
+               << "does not exist or is invalid.";
     return;
     }
 
-  this->InformaticsDialog->SetIconsFile(this->Projects[0]->InformaticsIconFile);
+  this->InformaticsDialog->SetIconsFile(
+    stdString(this->Projects[0]->InformaticsIconFile));
   this->InformaticsDialog->Initialize();
   this->InformaticsDialog->exec();
 }
@@ -5088,8 +5090,9 @@ void vpViewCore::forceUpdate()
         for (size_t i = 0, end = this->Projects.size(); i < end; ++i)
           {
           vpProject* project = this->Projects[i];
-          double in[4] = {project->AOIUpperLeftLatLon[1],
-                          project->AOIUpperLeftLatLon[0], 0, 1.0};
+          const auto& aoiUL =
+            getCorner(project->AOI, 0, vgGeodesy::LatLon_Wgs84);
+          double in[4] = {aoiUL.Easting, aoiUL.Northing, 0.0, 1.0};
           double out[4];
           this->LatLonToImageMatrix->MultiplyPoint(in, out);
           if (out[3] != 0)
@@ -5622,56 +5625,24 @@ void vpViewCore::createDisplayOutline(vpProject* project)
 
   if (this->UseGeoCoordinates)
     {
-    if (project->AOIUpperLeftLatLon[0] != 444)
+    if (project->AOI.GCS > 0)
       {
-      double ul[] = { project->AOIUpperLeftLatLon[1],
-                      project->AOIUpperLeftLatLon[0], 0.0, 1.0 };
-      this->LatLonToWorldMatrix->MultiplyPoint(ul, ul);
-      ul[0] /= ul[3];
-      ul[1] /= ul[3];
-      if (project->AOILowerRightLatLon[0] != 444)
-        {
-        double lr[] = { project->AOILowerRightLatLon[1],
-                        project->AOILowerRightLatLon[0], 0.0, 1.0 };
-        this->LatLonToWorldMatrix->MultiplyPoint(lr, lr);
-        lr[0] /= lr[3];
-        lr[1] /= lr[3];
-        if (project->AOILowerLeftLatLon[0] != 444 &&
-            project->AOIUpperRightLatLon[0] != 444)
-          {
-          // All 4 corners.
-          double ll[] = { project->AOILowerLeftLatLon[1],
-                          project->AOILowerLeftLatLon[0], 0.0, 1.0 };
-          this->LatLonToWorldMatrix->MultiplyPoint(ll, ll);
-          ll[0] /= ll[3];
-          ll[1] /= ll[3];
-          double ur[] = { project->AOIUpperRightLatLon[1],
-                          project->AOIUpperRightLatLon[0], 0.0, 1.0 };
-          this->LatLonToWorldMatrix->MultiplyPoint(ur, ur);
-          ur[0] /= ur[3];
-          ur[1] /= ur[3];
-          aoiOutlinePoints->SetPoint(0, ll);
-          aoiOutlinePoints->SetPoint(1, lr);
-          aoiOutlinePoints->SetPoint(2, ur);
-          aoiOutlinePoints->SetPoint(3, ul);
-          }
-        else
-          {
-          // Two corners.
-          aoiOutlinePoints->SetPoint(0, ul[0], lr[1], 0);
-          aoiOutlinePoints->SetPoint(1, lr[0], lr[1], 0);
-          aoiOutlinePoints->SetPoint(2, lr[0], ul[1], 0);
-          aoiOutlinePoints->SetPoint(3, ul[0], ul[1], 0);
-          }
-        }
-      else
-        {
-        // Just one corner - show a 'notch' in the upper left corner.
-        aoiOutlinePoints->SetPoint(0, ul[0], ul[1] - 100, 0);
-        aoiOutlinePoints->SetPoint(1, ul[0], ul[1], 0);
-        aoiOutlinePoints->SetPoint(2, ul[0] + 100, ul[1], 0);
-        aoiOutlinePoints->SetPoint(3, ul[0], ul[1], 0);
-        }
+      const auto& aoi =
+        vgGeodesy::convertGcs(project->AOI, vgGeodesy::LatLon_Wgs84);
+      const auto& corners = aoi.Coordinate;
+      double ul[3] = {corners[0].Easting, corners[0].Northing, 0.0};
+      double ur[3] = {corners[1].Easting, corners[1].Northing, 0.0};
+      double lr[3] = {corners[2].Easting, corners[2].Northing, 0.0};
+      double ll[3] = {corners[3].Easting, corners[3].Northing, 0.0};
+      vtkVgApplyHomography(ul, this->LatLonToWorldMatrix, ul);
+      vtkVgApplyHomography(ur, this->LatLonToWorldMatrix, ur);
+      vtkVgApplyHomography(lr, this->LatLonToWorldMatrix, lr);
+      vtkVgApplyHomography(ll, this->LatLonToWorldMatrix, ll);
+
+      aoiOutlinePoints->SetPoint(0, ll);
+      aoiOutlinePoints->SetPoint(1, lr);
+      aoiOutlinePoints->SetPoint(2, ur);
+      aoiOutlinePoints->SetPoint(3, ul);
       }
     else
       {
@@ -5683,58 +5654,26 @@ void vpViewCore::createDisplayOutline(vpProject* project)
     }
   else if (this->UseRawImageCoordinates)
     {
-    if (project->AOILowerRightLatLon[0] != 444)
+    if (project->AOI.GCS > 0)
       {
-      double lr[4] = { project->AOILowerRightLatLon[1],
-                       project->AOILowerRightLatLon[0], 0, 1.0 };
+      const auto& aoi =
+        vgGeodesy::convertGcs(project->AOI, vgGeodesy::LatLon_Wgs84);
+      const auto& corners = aoi.Coordinate;
+      double ur[3] = {corners[1].Easting, corners[1].Northing, 0.0};
+      double lr[3] = {corners[2].Easting, corners[2].Northing, 0.0};
+      double ll[3] = {corners[3].Easting, corners[3].Northing, 0.0};
+      vtkVgApplyHomography(ur, this->LatLonToWorldMatrix, ur);
+      vtkVgApplyHomography(lr, this->LatLonToWorldMatrix, lr);
+      vtkVgApplyHomography(ll, this->LatLonToWorldMatrix, ll);
 
-      this->LatLonToWorldMatrix->MultiplyPoint(lr, lr);
-      if (lr[3] != 0)
-        {
-        lr[0] /= lr[3];
-        lr[1] /= lr[3];
-        }
-
-      if (project->AOILowerLeftLatLon[0] != 444 &&
-          project->AOIUpperRightLatLon[0] != 444)
-        {
-        // All four corners.
-        double ll[4] = { project->AOILowerLeftLatLon[1],
-                         project->AOILowerLeftLatLon[0], 0, 1.0 };
-
-        this->LatLonToWorldMatrix->MultiplyPoint(ll, ll);
-        if (ll[3] != 0)
-          {
-          ll[0] /= ll[3];
-          ll[1] /= ll[3];
-          }
-        double ur[4] = { project->AOIUpperRightLatLon[1],
-                         project->AOIUpperRightLatLon[0], 0, 1.0 };
-
-        this->LatLonToWorldMatrix->MultiplyPoint(ur, ur);
-        if (ur[3] != 0)
-          {
-          ur[0] /= ur[3];
-          ur[1] /= ur[3];
-          }
-
-        aoiOutlinePoints->SetPoint(0, ll[0], ll[1], 0);
-        aoiOutlinePoints->SetPoint(1, lr[0], lr[1], 0);
-        aoiOutlinePoints->SetPoint(2, ur[0], ur[1], 0);
-        aoiOutlinePoints->SetPoint(3, 0, 0, 0);
-        }
-      else
-        {
-        // Two corners.
-        aoiOutlinePoints->SetPoint(0, 0, lr[1], 0);
-        aoiOutlinePoints->SetPoint(1, lr[0], lr[1], 0);
-        aoiOutlinePoints->SetPoint(2, lr[0], 0, 0);
-        aoiOutlinePoints->SetPoint(3, 0, 0, 0);
-        }
+      aoiOutlinePoints->SetPoint(0, ll);
+      aoiOutlinePoints->SetPoint(1, lr);
+      aoiOutlinePoints->SetPoint(2, ur);
+      aoiOutlinePoints->SetPoint(3, 0, 0, 0);
       }
     else
       {
-      // Just one corner - show a 'notch' in the upper left corner.
+      // Don't know AOI corners; show a 'notch' in the upper left corner
       aoiOutlinePoints->SetPoint(0, 0, -100, 0);
       aoiOutlinePoints->SetPoint(1, 0, 0, 0);
       aoiOutlinePoints->SetPoint(2, 100, 0, 0);
@@ -5743,11 +5682,12 @@ void vpViewCore::createDisplayOutline(vpProject* project)
     }
   else // Inverted image coordinates
     {
+    const auto x = project->AnalysisDimensions.width() - 1;
+    const auto y = project->AnalysisDimensions.height() - 1;
     aoiOutlinePoints->SetPoint(0, 0, 0, 0);
-    aoiOutlinePoints->SetPoint(1, project->AnalysisDimensions[0] - 1, 0, 0);
-    aoiOutlinePoints->SetPoint(2, project->AnalysisDimensions[0] - 1,
-                               project->AnalysisDimensions[1] - 1, 0);
-    aoiOutlinePoints->SetPoint(3, 0, project->AnalysisDimensions[1] - 1, 0);
+    aoiOutlinePoints->SetPoint(1, x, 0, 0);
+    aoiOutlinePoints->SetPoint(2, x, y, 0);
+    aoiOutlinePoints->SetPoint(3, 0, y, 0);
     }
 
   vtkSmartPointer<vtkCellArray> aoiOutlineLines = vtkSmartPointer<vtkCellArray>::New();
@@ -5773,14 +5713,14 @@ void vpViewCore::handleDataSetNotFound(vpProject* project)
 {
   emit this->criticalError(
     QString("Unable to read dataset using path (\"%1\").\n").arg(
-      qtString(project->DataSetSpecifier)));
+      project->DataSetSpecifier));
 }
 
 //-----------------------------------------------------------------------------
-void vpViewCore::handleFileNotFound(const std::string& tag, const std::string& file)
+void vpViewCore::handleFileNotFound(const char* tag, const QString& file)
 {
   QString warningMsg = tr("Unable to find file ( %1 ) for %2")
-                         .arg(QString(file.c_str()), QString(tag.c_str()));
+                         .arg(file, QString{tag});
 
   emit this->warningError(warningMsg);
 }
@@ -6262,8 +6202,9 @@ void vpViewCore::addFilterRegion(const std::string& name,
     if (this->UseRawImageCoordinates)
       {
       // Convert from lat-long points to track-space points
-      double in[4] = { this->Projects[0]->AOIUpperLeftLatLon[1],
-                       this->Projects[0]->AOIUpperLeftLatLon[0], 0, 1.0 };
+      const auto& aoiUL =
+        getCorner(this->Projects[0]->AOI, 0, vgGeodesy::LatLon_Wgs84);
+      double in[4] = {aoiUL.Easting, aoiUL.Northing, 0.0, 1.0};
       double out[4];
       this->LatLonToImageMatrix->MultiplyPoint(in, out);
       if (out[3] == 0.0)
@@ -6316,7 +6257,7 @@ void vpViewCore::addFilterRegion(const std::string& name,
     else
       {
       // Normal image coordinate mode, all we do is y-flip
-      double maxY = this->Projects[0]->AnalysisDimensions[1] - 1;
+      double maxY = this->Projects[0]->AnalysisDimensions.height() - 1;
       for (size_t i = 0, size = points.size(); i < size; i += 2)
         {
         double point[4] =
@@ -8377,7 +8318,7 @@ void vpViewCore::startExternalProcess(QString program, QStringList fields,
     if ((findToken(fields, "${FF}", Qt::CaseInsensitive) != -1) &&
         this->ExternalExecuteMode == 1) // Scene Learning mode
       {
-      if (currentProject->FiltersFile.empty())
+      if (currentProject->FiltersFile.isEmpty())
         {
         QMessageBox::warning(0, QString(),
           "Aborting process execution; "
@@ -8385,7 +8326,7 @@ void vpViewCore::startExternalProcess(QString program, QStringList fields,
         return;
         }
 
-      QFileInfo filterFileInfo(currentProject->FiltersFile.c_str());
+      QFileInfo filterFileInfo{currentProject->FiltersFile};
       this->ExternalProcessOutputFile = filterFileInfo.absoluteFilePath();
       startExternalProcessAfterFilterExport = true;
       }
@@ -8393,11 +8334,11 @@ void vpViewCore::startExternalProcess(QString program, QStringList fields,
     // Mapping of tokens to their values
     QHash<QString, QString> externalProcessKeywords;
     externalProcessKeywords["${TF}"] =
-      (QString("-trackfile ") + qtString(currentProject->TracksFile));
+      (QString("-trackfile ") + currentProject->TracksFile);
     externalProcessKeywords["${EF}"] =
-      (QString("-eventfile ") + qtString(currentProject->EventsFile));
+      (QString("-eventfile ") + currentProject->EventsFile);
     externalProcessKeywords["${FF}"] =
-      (QString("-filtersfile ") + qtString(currentProject->FiltersFile));
+      (QString("-filtersfile ") + currentProject->FiltersFile);
     externalProcessKeywords["${PI}"] =
       (QString("-inputfile ") + processInput);
     externalProcessKeywords["${PO}"] =
@@ -8465,7 +8406,7 @@ void vpViewCore::toWindowCoordinates(double &x, double &y)
 {
   if (!this->Projects.empty())
     {
-    double maxY = this->Projects[0]->AnalysisDimensions[1] - 1;
+    double maxY = this->Projects[0]->AnalysisDimensions.height() - 1;
     y = maxY - y;
     }
 }
@@ -8481,7 +8422,7 @@ void vpViewCore::toGraphicsCoordinates(double &x, double &y)
 {
   if (!this->Projects.empty())
     {
-    double maxY = this->Projects[0]->AnalysisDimensions[1] - 1;
+    double maxY = this->Projects[0]->AnalysisDimensions.height() - 1;
     y = maxY - y;
     }
 }
@@ -8526,7 +8467,7 @@ void vpViewCore::reactToExternalProcessFileChanged(QString changedFile)
 
   if (this->ExecutedExternalProcessMode == 1)  // Learning mode
     {
-    this->loadFilters(this->ExternalProcessOutputFile.toStdString().c_str());
+    this->loadFilters(qPrintable(this->ExternalProcessOutputFile));
     return;
     }
 
@@ -8534,48 +8475,48 @@ void vpViewCore::reactToExternalProcessFileChanged(QString changedFile)
   static int memoryProjectCounter = 0;
   QScopedPointer<vpProject> project(new vpProject(this->CurrentProjectId++));
   project->CopyConfig(*this->Projects[this->SessionView->GetCurrentSession()]);
-  QString projectName(
-    this->Projects[this->SessionView->GetCurrentSession()]->Name.c_str());
+  QString projectName =
+    this->Projects[this->SessionView->GetCurrentSession()]->Name;
   projectName += QString(".%1").arg(memoryProjectCounter++);
-  project->Name = projectName.toStdString();
+  project->Name = projectName;
 
   // For now, this is specific to FSE
   if (this->ExecutedExternalProcessMode == 0)
     {
-    project->SceneElementsFile = this->ExternalProcessOutputFile.toStdString();
+    project->SceneElementsFile = this->ExternalProcessOutputFile;
     project->SetIsValid(project->SceneElementsFile, vpProject::FILE_EXIST);
     }
 
   // For now this is specific to normalcy anamoly
   if (this->ExecutedExternalProcessMode == 2)
     {
-    project->EventsFile = this->ExternalProcessOutputFile.toStdString();
+    project->EventsFile = this->ExternalProcessOutputFile;
     project->SetIsValid(project->EventsFile, vpProject::FILE_EXIST);
     }
 
   // For now this is specific to normalcy anamoly
   if (this->ExecutedExternalProcessMode == 3)
     {
-    project->ActivitiesFile = this->ExternalProcessOutputFile.toStdString();
+    project->ActivitiesFile = this->ExternalProcessOutputFile;
     project->SetIsValid(project->ActivitiesFile, vpProject::FILE_EXIST);
     }
 
   project->FrameNumberOffset = this->FrameNumberOffset;
 
   // If filters file is set, wipe out all existing filters before loading
-  if (!project->FiltersFile.empty())
+  if (!project->FiltersFile.isEmpty())
     {
     emit removeAllFilters();
     }
 
 #ifdef VISGUI_USE_VIDTK
   QSharedPointer<vpVidtkFileIO> fileIO(new vpVidtkFileIO);
-  fileIO->SetTracksFileName(project->TracksFile.c_str());
-  fileIO->SetTrackTraitsFileName(project->TrackTraitsFile.c_str());
-  fileIO->SetEventsFileName(project->EventsFile.c_str());
-  fileIO->SetEventLinksFileName(project->EventLinksFile.c_str());
-  fileIO->SetActivitiesFileName(project->ActivitiesFile.c_str());
-  fileIO->SetFseTracksFileName(project->SceneElementsFile.c_str());
+  fileIO->SetTracksFileName(qPrintable(project->TracksFile));
+  fileIO->SetTrackTraitsFileName(qPrintable(project->TrackTraitsFile));
+  fileIO->SetEventsFileName(qPrintable(project->EventsFile));
+  fileIO->SetEventLinksFileName(qPrintable(project->EventLinksFile));
+  fileIO->SetActivitiesFileName(qPrintable(project->ActivitiesFile));
+  fileIO->SetFseTracksFileName(qPrintable(project->SceneElementsFile));
   project->ModelIO = fileIO;
   this->processProject(project);
 #else

--- a/Applications/VpView/vpViewCore.h
+++ b/Applications/VpView/vpViewCore.h
@@ -678,7 +678,7 @@ private:
 
   // Helper functions.
   void handleDataSetNotFound(vpProject* project);
-  void handleFileNotFound(const std::string& tag, const std::string& file);
+  void handleFileNotFound(const char* tag, const QString& file);
 
   void initializeImageSource();
 

--- a/Libraries/QtVgCommon/vgColor.h
+++ b/Libraries/QtVgCommon/vgColor.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -9,9 +9,12 @@
 
 #include <vgExport.h>
 
+template <typename T> class QList;
+
 class QColor;
 class QSettings;
 class QString;
+class QStringList;
 
 class QTVG_COMMON_EXPORT vgColor
 {
@@ -58,6 +61,7 @@ public:
     AutoAlpha
     };
 
+  QList<int> toList() const;
   QString toString(StringType = AutoAlpha) const;
   QColor toQColor() const;
 
@@ -69,6 +73,8 @@ public:
   void write(QSettings&, const QString& key) const;
 
 protected:
+  bool read(const QStringList&);
+
   ComponentData d;
 };
 

--- a/Libraries/VgCommon/vgGeoTypes.h
+++ b/Libraries/VgCommon/vgGeoTypes.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -49,9 +49,10 @@ template <int K>
 struct vgGeocodedFixedPoly : vgGeoSystem
 {
   vgGeoRawCoordinate Coordinate[K];
+  constexpr static int Size = K;
 };
 
-typedef vgGeocodedFixedPoly<4> vgGeocodedTile;
+using vgGeocodedTile = vgGeocodedFixedPoly<4>;
 
 //-----------------------------------------------------------------------------
 struct vgGeocodedPoly : vgGeoSystem

--- a/Libraries/VgCommon/vgGeodesy.cxx
+++ b/Libraries/VgCommon/vgGeodesy.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -269,6 +269,36 @@ vgGeocodedCoordinate vgGeodesy::convertGcs(
   pj_free(fromProj);
   pj_free(toProj);
 
+  return out;
+}
+
+//-----------------------------------------------------------------------------
+vgGeocodedTile vgGeodesy::convertGcs(const vgGeocodedTile& in, int desiredGcs)
+{
+  // Validate input
+  if (in.GCS < 0)
+    return {};
+
+  // Check for no-op
+  if (in.GCS == desiredGcs)
+    return in;
+
+  // Prepare for conversion
+  vgGeocodedCoordinate temp;
+  vgGeoRawCoordinate& raw = temp;
+  temp.GCS = in.GCS;
+  vgGeocodedTile out;
+
+  // Convert points
+  for (int n = 0; n < in.Size; ++n)
+    {
+    raw = in.Coordinate[n];
+    out.Coordinate[n] = convertGcs(temp, desiredGcs);
+    }
+
+  out.GCS = desiredGcs;
+
+  // Return converted result
   return out;
 }
 

--- a/Libraries/VgCommon/vgGeodesy.h
+++ b/Libraries/VgCommon/vgGeodesy.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -13,6 +13,9 @@
 
 struct vgGeocodedCoordinate;
 struct vgGeocodedPoly;
+
+template <int K> struct vgGeocodedFixedPoly;
+using vgGeocodedTile = vgGeocodedFixedPoly<4>;
 
 namespace vgGeodesy
 {
@@ -35,6 +38,9 @@ namespace vgGeodesy
 
   VG_COMMON_EXPORT vgGeocodedCoordinate convertGcs(
     const vgGeocodedCoordinate&, int desiredGcs);
+
+  VG_COMMON_EXPORT vgGeocodedTile convertGcs(
+    const vgGeocodedTile&, int desiredGcs);
 
   VG_COMMON_EXPORT vgGeocodedPoly convertGcs(
     const vgGeocodedPoly&, int desiredGcs);


### PR DESCRIPTION
This refactors the *\<your favorite epithet here\>* out of vpProject:

- C arrays are out, C++ object types are in. This simplifies initialization, copying and validity checking.
- `std::string` and `std::map` are out, `QString` and `QHash` are in. This simplifies the new parser, and also many uses of these members, which often needed to be converted to `QString` anyway. (Using `QHash` instead of `std::map` is significantly more convenient for implementing `vpProject::IsValid`.)
- Many members are moved to a new base class, `vpProjectBase`. This class is copyable, with default copy ctor and assignment operator. `CopyConfig` is implemented using these, which *drastically* simplifies its implementation.
- Uses of `vpProject::FileState` are no longer demoted to `int`.
- Qt is used for filesystem operations, replacing use of vtksys and manual string manipulation.

...and implements a new parser based on `QSettings` rather than VidTK's `config_block`. The new parser thus has no (additional) external dependencies, which allows us to read project files when VidTK is not available (and does not simply shift to depending on KWIVER instead). This parser is *partly* compatible:

- AOI's are stored in a settings group. The AOI [GCS](https://en.wikipedia.org/wiki/Geographic_coordinate_system) may now be specified, as may coordinates in degree, minute, second notation (caveat; if using ASCII `"` 'quotation mark' instead of U+2033 `″` 'double prime', the character must be escaped).
- Multi-number values must separate the numbers with a comma.
- The track override color uses integer values (0-255) instead of real values (0.0 - 1.0). This is due to use of `vgColor` for reading, which makes it consistent with how colors are read and written to application settings.
- Parsing of the image-to-GCS matrix is not currently implemented. (Not technically difficult, but I've spent long enough on this for the moment...)