### PR TITLE
Change vcl to std:: (affects vidtk related files)

### DIFF
--- a/Applications/VpView/vpVidtkActivityIO.cxx
+++ b/Applications/VpView/vpVidtkActivityIO.cxx
@@ -41,7 +41,7 @@ bool vpVidtkActivityIO::ReadActivities()
     return false;
     }
 
-  vcl_vector<vidtk::activity_sptr>::iterator activityIter = this->Activities.begin();
+  std::vector<vidtk::activity_sptr>::iterator activityIter = this->Activities.begin();
   for (; activityIter != this->Activities.end(); activityIter++)
     {
     vtkSmartPointer<vtkVgActivity> activity = vtkSmartPointer<vtkVgActivity>::New();
@@ -81,8 +81,8 @@ bool vpVidtkActivityIO::SetupActivity(
   vtkVgEventModel* eventModel = this->ActivityManager->GetEventModel();
   assert(eventModel);
 
-  const vcl_vector<vidtk::event_sptr>& events = vidtkActivity->get_supporting_events();
-  vcl_vector<vidtk::event_sptr>::const_iterator eventIter = events.begin();
+  const std::vector<vidtk::event_sptr>& events = vidtkActivity->get_supporting_events();
+  std::vector<vidtk::event_sptr>::const_iterator eventIter = events.begin();
   for (; eventIter != events.end(); eventIter++)
     {
     vtkVgEvent* theEvent = eventModel->GetEvent((*eventIter)->get_id());

--- a/Applications/VpView/vpVidtkActivityIO.h
+++ b/Applications/VpView/vpVidtkActivityIO.h
@@ -31,8 +31,8 @@ private:
 
 private:
   vpVidtkReader& Reader;
-  vcl_vector<vidtk::activity_sptr> Activities;
-  vcl_map<vtkVgActivity*, vidtk::activity_sptr> ActivityMap;
+  std::vector<vidtk::activity_sptr> Activities;
+  std::map<vtkVgActivity*, vidtk::activity_sptr> ActivityMap;
 };
 
 #endif // __vpVidtkActivityIO_h

--- a/Applications/VpView/vpVidtkEventIO.cxx
+++ b/Applications/VpView/vpVidtkEventIO.cxx
@@ -44,12 +44,12 @@ static vidtk::event_sptr CreateVidtkEvent(int type)
 
 //-----------------------------------------------------------------------------
 vpVidtkEventIO::vpVidtkEventIO(vpVidtkReader& reader,
-                               vcl_map<vtkVgEvent*, vidtk::event_sptr>& eventMap,
-                               vcl_map<unsigned int, vtkIdType>&
+                               std::map<vtkVgEvent*, vidtk::event_sptr>& eventMap,
+                               std::map<unsigned int, vtkIdType>&
                                  sourceEventIdToModelIdMap,
-                               const vcl_map<vtkVgTrack*, vidtk::track_sptr>&
+                               const std::map<vtkVgTrack*, vidtk::track_sptr>&
                                  trackMap,
-                               const vcl_map<unsigned int, vtkIdType>&
+                               const std::map<unsigned int, vtkIdType>&
                                  sourceTrackIdToModelIdMap,
                                vtkVgEventModel* eventModel,
                                vtkVgEventTypeRegistry* eventTypes) :
@@ -178,9 +178,9 @@ bool vpVidtkEventIO::WriteEvents(const char* filename) const
     return false;
     }
 
-  vcl_vector<vidtk::track_sptr> empty;
-  vcl_vector<vidtk::timestamp> trackBeginTimes(2);
-  vcl_vector<vidtk::timestamp> trackEndTimes(2);
+  std::vector<vidtk::track_sptr> empty;
+  std::vector<vidtk::timestamp> trackBeginTimes(2);
+  std::vector<vidtk::timestamp> trackEndTimes(2);
 
   this->EventModel->InitEventTraversal();
   while (vtkVgEvent* event = this->EventModel->GetNextEvent().GetEvent())
@@ -261,7 +261,7 @@ bool vpVidtkEventIO::WriteEvents(const char* filename) const
                                 vgEndFrame.GetFrameNumber());
 
       vidtk::track_sptr t;
-      vcl_map<vtkVgTrack*, vidtk::track_sptr>::const_iterator itr =
+      std::map<vtkVgTrack*, vidtk::track_sptr>::const_iterator itr =
         this->TrackMap.find(track);
       if (itr != this->TrackMap.end())
         {
@@ -280,7 +280,7 @@ bool vpVidtkEventIO::WriteEvents(const char* filename) const
 
       // update the spatial bounds of the event
       bool foundStart = false;
-      const vcl_vector<vidtk::track_state_sptr>& history = t->history();
+      const std::vector<vidtk::track_state_sptr>& history = t->history();
       for (unsigned j = 0; j < history.size(); ++j)
         {
         // seek to the initial frame of the event track in the history
@@ -370,8 +370,8 @@ bool vpVidtkEventIO::SetupEvent(const vidtk::event_sptr vidtkEvent,
   // Tracks associated with this event.
   unsigned int numOfTracks = vidtkEvent->get_num_parent_tracks();
 
-  vcl_vector<vidtk::timestamp> trackBeginTimeStamp = vidtkEvent->get_tracks_begin();
-  vcl_vector<vidtk::timestamp> trackEndTimeStamp   = vidtkEvent->get_tracks_end();
+  std::vector<vidtk::timestamp> trackBeginTimeStamp = vidtkEvent->get_tracks_begin();
+  std::vector<vidtk::timestamp> trackEndTimeStamp   = vidtkEvent->get_tracks_end();
 
   // Check the assumption here.
   assert(trackBeginTimeStamp.size() == trackEndTimeStamp.size());
@@ -379,8 +379,8 @@ bool vpVidtkEventIO::SetupEvent(const vidtk::event_sptr vidtkEvent,
   vtkVgTrackModel* trackModel = this->EventModel->GetTrackModel();
   assert(trackModel);
 
-  vcl_vector<unsigned int> parentTracksIds;
-  vcl_vector<vidtk::track_sptr> parentTracks;
+  std::vector<unsigned int> parentTracksIds;
+  std::vector<vidtk::track_sptr> parentTracks;
   parentTracksIds.reserve(numOfTracks);
   parentTracks.reserve(numOfTracks);
 
@@ -390,7 +390,7 @@ bool vpVidtkEventIO::SetupEvent(const vidtk::event_sptr vidtkEvent,
 
     // Check if the id of the track in the model is different than the source
     // id, and if so, use that one when looking up the track in the model.
-    vcl_map<unsigned int, vtkIdType>::const_iterator itr =
+    std::map<unsigned int, vtkIdType>::const_iterator itr =
       this->SourceTrackIdToModelIdMap.find(srcTrackId);
 
     vtkIdType trackId;
@@ -517,8 +517,8 @@ bool vpVidtkEventIO::SetupNodeEvent(const vidtk::event_sptr vidtkEvent,
   // Add tracks.
   unsigned numOfTracks = vidtkEvent->get_num_parent_tracks();
 
-  vcl_vector<vidtk::timestamp> trackBeginTimeStamp = vidtkEvent->get_tracks_begin();
-  vcl_vector<vidtk::timestamp> trackEndTimeStamp   = vidtkEvent->get_tracks_end();
+  std::vector<vidtk::timestamp> trackBeginTimeStamp = vidtkEvent->get_tracks_begin();
+  std::vector<vidtk::timestamp> trackEndTimeStamp   = vidtkEvent->get_tracks_end();
 
   // Check the assumption here.
   assert(trackBeginTimeStamp.size() == trackEndTimeStamp.size());

--- a/Applications/VpView/vpVidtkEventIO.h
+++ b/Applications/VpView/vpVidtkEventIO.h
@@ -23,10 +23,10 @@ class vpVidtkEventIO : public vpEventIO
 {
 public:
   vpVidtkEventIO(vpVidtkReader& reader,
-                 vcl_map<vtkVgEvent*, vidtk::event_sptr>& eventMap,
-                 vcl_map<unsigned int, vtkIdType>& sourceEventIdToModelIdMap,
-                 const vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
-                 const vcl_map<unsigned int, vtkIdType>& sourceTrackIdToModelIdMap,
+                 std::map<vtkVgEvent*, vidtk::event_sptr>& eventMap,
+                 std::map<unsigned int, vtkIdType>& sourceEventIdToModelIdMap,
+                 const std::map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
+                 const std::map<unsigned int, vtkIdType>& sourceTrackIdToModelIdMap,
                  vtkVgEventModel* eventModel,
                  vtkVgEventTypeRegistry* eventTypes = 0);
 
@@ -52,11 +52,11 @@ private:
 
 private:
   vpVidtkReader& Reader;
-  vcl_vector<vidtk::event_sptr> Events;
-  vcl_map<vtkVgEvent*, vidtk::event_sptr>& EventMap;
-  vcl_map<unsigned int, vtkIdType>& SourceEventIdToModelIdMap;
-  const vcl_map<vtkVgTrack*, vidtk::track_sptr>& TrackMap;
-  const vcl_map<unsigned int, vtkIdType>& SourceTrackIdToModelIdMap;
+  std::vector<vidtk::event_sptr> Events;
+  std::map<vtkVgEvent*, vidtk::event_sptr>& EventMap;
+  std::map<unsigned int, vtkIdType>& SourceEventIdToModelIdMap;
+  const std::map<vtkVgTrack*, vidtk::track_sptr>& TrackMap;
+  const std::map<unsigned int, vtkIdType>& SourceTrackIdToModelIdMap;
 };
 
 #endif // __vpVidtkEventIO_h

--- a/Applications/VpView/vpVidtkFileEventIO.cxx
+++ b/Applications/VpView/vpVidtkFileEventIO.cxx
@@ -12,10 +12,10 @@
 //-----------------------------------------------------------------------------
 vpVidtkFileEventIO::vpVidtkFileEventIO(
   vpVidtkFileReader& reader,
-  vcl_map<vtkVgEvent*, vidtk::event_sptr>& eventMap,
-  vcl_map<unsigned int, vtkIdType>& sourceEventIdToModelIdMap,
-  const vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
-  const vcl_map<unsigned int, vtkIdType>& sourceTrackIdToModelIdMap,
+  std::map<vtkVgEvent*, vidtk::event_sptr>& eventMap,
+  std::map<unsigned int, vtkIdType>& sourceEventIdToModelIdMap,
+  const std::map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
+  const std::map<unsigned int, vtkIdType>& sourceTrackIdToModelIdMap,
   vtkVgEventModel* eventModel,
   vtkVgEventTypeRegistry* eventTypes) :
   vpVidtkEventIO(reader, eventMap, sourceEventIdToModelIdMap,

--- a/Applications/VpView/vpVidtkFileEventIO.h
+++ b/Applications/VpView/vpVidtkFileEventIO.h
@@ -15,10 +15,10 @@ class vpVidtkFileEventIO : public vpVidtkEventIO
 {
 public:
   vpVidtkFileEventIO(vpVidtkFileReader& reader,
-                     vcl_map<vtkVgEvent*, vidtk::event_sptr>& eventMap,
-                     vcl_map<unsigned int, vtkIdType>& sourceEventIdToModelIdMap,
-                     const vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
-                     const vcl_map<unsigned int, vtkIdType>& sourceTrackIdToModelIdMap,
+                     std::map<vtkVgEvent*, vidtk::event_sptr>& eventMap,
+                     std::map<unsigned int, vtkIdType>& sourceEventIdToModelIdMap,
+                     const std::map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
+                     const std::map<unsigned int, vtkIdType>& sourceTrackIdToModelIdMap,
                      vtkVgEventModel* eventModel,
                      vtkVgEventTypeRegistry* eventTypes = 0);
 

--- a/Applications/VpView/vpVidtkFileReader.cxx
+++ b/Applications/VpView/vpVidtkFileReader.cxx
@@ -26,7 +26,7 @@
 #include <QUrl>
 
 //-----------------------------------------------------------------------------
-bool vpVidtkFileReader::ReadTracks(vcl_vector<vidtk::track_sptr>& outTracks)
+bool vpVidtkFileReader::ReadTracks(std::vector<vidtk::track_sptr>& outTracks)
 {
   if (this->TracksFileName.empty())
     {
@@ -178,7 +178,7 @@ bool vpVidtkFileReader::ReadTracks(vcl_vector<vidtk::track_sptr>& outTracks)
 }
 
 //-----------------------------------------------------------------------------
-bool vpVidtkFileReader::ReadEvents(vcl_vector<vidtk::event_sptr>& events)
+bool vpVidtkFileReader::ReadEvents(std::vector<vidtk::event_sptr>& events)
 {
   if (this->EventsFileName.empty())
     {
@@ -191,7 +191,7 @@ bool vpVidtkFileReader::ReadEvents(vcl_vector<vidtk::event_sptr>& events)
     return false;
     }
 
-  vcl_map<vidtk::event_sptr, unsigned int> stepMap;
+  std::map<vidtk::event_sptr, unsigned int> stepMap;
   if (reader.read(events, stepMap))
     {
     // Build the map of event ids to events that will be needed if we read
@@ -209,7 +209,7 @@ bool vpVidtkFileReader::ReadEvents(vcl_vector<vidtk::event_sptr>& events)
 
 //-----------------------------------------------------------------------------
 bool vpVidtkFileReader::ReadActivities(
-  vcl_vector<vidtk::activity_sptr>& activities)
+  std::vector<vidtk::activity_sptr>& activities)
 {
   if (this->ActivitiesFileName.empty())
     {

--- a/Applications/VpView/vpVidtkFileReader.h
+++ b/Applications/VpView/vpVidtkFileReader.h
@@ -13,15 +13,15 @@
 class vpVidtkFileReader : public vpFileReader, public vpVidtkReader
 {
 public:
-  virtual bool ReadTracks(vcl_vector<vidtk::track_sptr>& tracks);
-  virtual bool ReadEvents(vcl_vector<vidtk::event_sptr>& events);
-  virtual bool ReadActivities(vcl_vector<vidtk::activity_sptr>& activities);
+  virtual bool ReadTracks(std::vector<vidtk::track_sptr>& tracks);
+  virtual bool ReadEvents(std::vector<vidtk::event_sptr>& events);
+  virtual bool ReadActivities(std::vector<vidtk::activity_sptr>& activities);
 
   virtual void SetImageHeight(unsigned int imageHeight);
   virtual unsigned int GetImageHeight() const;
 
 private:
-  vcl_map<unsigned int, vidtk::event_sptr> EventMap;
+  std::map<unsigned int, vidtk::event_sptr> EventMap;
 };
 
 #endif // __vpVidtkFileReader_h

--- a/Applications/VpView/vpVidtkFileTrackIO.cxx
+++ b/Applications/VpView/vpVidtkFileTrackIO.cxx
@@ -12,8 +12,8 @@
 //-----------------------------------------------------------------------------
 vpVidtkFileTrackIO::vpVidtkFileTrackIO(
   vpVidtkFileReader& reader,
-  vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
-  vcl_map<unsigned int, vtkIdType>& sourceIdToModelIdMap,
+  std::map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
+  std::map<unsigned int, vtkIdType>& sourceIdToModelIdMap,
   vtkVpTrackModel* trackModel,
   TrackStorageMode storageMode,
   TrackTimeStampMode timeStampMode,

--- a/Applications/VpView/vpVidtkFileTrackIO.h
+++ b/Applications/VpView/vpVidtkFileTrackIO.h
@@ -15,8 +15,8 @@ class vpVidtkFileTrackIO : public vpVidtkTrackIO
 {
 public:
   vpVidtkFileTrackIO(vpVidtkFileReader& reader,
-                     vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
-                     vcl_map<unsigned int, vtkIdType>& sourceIdToModelIdMap,
+                     std::map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
+                     std::map<unsigned int, vtkIdType>& sourceIdToModelIdMap,
                      vtkVpTrackModel* trackModel,
                      TrackStorageMode storageMode,
                      TrackTimeStampMode timeStampMode,

--- a/Applications/VpView/vpVidtkIO.cxx
+++ b/Applications/VpView/vpVidtkIO.cxx
@@ -70,7 +70,7 @@ unsigned int vpVidtkIO::GetImageHeight() const
 }
 
 //-----------------------------------------------------------------------------
-void vpVidtkIO::UpdateTracks(const vcl_vector<vidtk::track_sptr>& tracks,
+void vpVidtkIO::UpdateTracks(const std::vector<vidtk::track_sptr>& tracks,
                              unsigned int updateStartFrame,
                              unsigned int updateEndFrame)
 {

--- a/Applications/VpView/vpVidtkIO.h
+++ b/Applications/VpView/vpVidtkIO.h
@@ -38,7 +38,7 @@ public:
   virtual void SetImageHeight(unsigned int imageHeight);
   virtual unsigned int GetImageHeight() const;
 
-  void UpdateTracks(const vcl_vector<vidtk::track_sptr>& tracks,
+  void UpdateTracks(const std::vector<vidtk::track_sptr>& tracks,
                     unsigned int updateStartFrame, unsigned int updateEndFrame);
 
 private:
@@ -46,10 +46,10 @@ private:
   virtual const vpVidtkReader& GetReader() const = 0;
 
 protected:
-  vcl_map<vtkVgTrack*, vidtk::track_sptr> TrackMap;
-  vcl_map<vtkVgEvent*, vidtk::event_sptr> EventMap;
-  vcl_map<unsigned int, vtkIdType> SourceTrackIdToModelIdMap;
-  vcl_map<unsigned int, vtkIdType> SourceEventIdToModelIdMap;
+  std::map<vtkVgTrack*, vidtk::track_sptr> TrackMap;
+  std::map<vtkVgEvent*, vidtk::event_sptr> EventMap;
+  std::map<unsigned int, vtkIdType> SourceTrackIdToModelIdMap;
+  std::map<unsigned int, vtkIdType> SourceEventIdToModelIdMap;
 };
 
 #endif // __vpVidtkIO_h

--- a/Applications/VpView/vpVidtkReader.h
+++ b/Applications/VpView/vpVidtkReader.h
@@ -16,9 +16,9 @@ class vpVidtkReader
 public:
   vpVidtkReader() : ImageHeight(0) {}
   virtual ~vpVidtkReader() {}
-  virtual bool ReadTracks(vcl_vector<vidtk::track_sptr>& tracks) = 0;
-  virtual bool ReadEvents(vcl_vector<vidtk::event_sptr>& events) = 0;
-  virtual bool ReadActivities(vcl_vector<vidtk::activity_sptr>& activities) = 0;
+  virtual bool ReadTracks(std::vector<vidtk::track_sptr>& tracks) = 0;
+  virtual bool ReadEvents(std::vector<vidtk::event_sptr>& events) = 0;
+  virtual bool ReadActivities(std::vector<vidtk::activity_sptr>& activities) = 0;
 
   void SetImageHeight(unsigned int imageHeight)
     { this->ImageHeight = imageHeight; }

--- a/Applications/VpView/vpVidtkTrackIO.cxx
+++ b/Applications/VpView/vpVidtkTrackIO.cxx
@@ -27,8 +27,8 @@
 
 //-----------------------------------------------------------------------------
 vpVidtkTrackIO::vpVidtkTrackIO(vpVidtkReader& reader,
-                               vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
-                               vcl_map<unsigned int, vtkIdType>&
+                               std::map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
+                               std::map<unsigned int, vtkIdType>&
                                  sourceIdToModelIdMap,
                                vtkVpTrackModel* trackModel,
                                TrackStorageMode storageMode,
@@ -134,7 +134,7 @@ bool vpVidtkTrackIO::WriteTracks(const char* filename,
   vidtk::track_writer_process writer("vpVidtkTrackIO::WriteTracks");
 
   std::string filestr(filename);
-  vcl_string format = filestr.substr(filestr.rfind('.') + 1);
+  std::string format = filestr.substr(filestr.rfind('.') + 1);
 
   if (!writer.set_params(
         writer.params().set_value("filename", filename)
@@ -153,8 +153,8 @@ bool vpVidtkTrackIO::WriteTracks(const char* filename,
   bool useWorldCoords = this->StorageMode == TSM_TransformedGeoCoords;
   bool useRawImageCoords = this->StorageMode == TSM_ImageCoords;
 
-  vcl_vector<vidtk::track_sptr> tracks;
-  vcl_vector<vidtk::image_object_sptr> objs(1);
+  std::vector<vidtk::track_sptr> tracks;
+  std::vector<vidtk::image_object_sptr> objs(1);
 
   vtkPoints* points = this->TrackModel->GetPoints();
   double imageYExtent = this->Reader.GetImageHeight() - 1;
@@ -165,10 +165,10 @@ bool vpVidtkTrackIO::WriteTracks(const char* filename,
   bool typesFileOpenFailed = false;
   bool regionsFileOpenFailed = false;
 
-  vcl_string typesFilename(filename);
+  std::string typesFilename(filename);
   typesFilename += ".types";
 
-  vcl_string regionsFilename(filename);
+  std::string regionsFilename(filename);
   regionsFilename += ".regions";
 
   // Remove any existing companion files
@@ -191,7 +191,7 @@ bool vpVidtkTrackIO::WriteTracks(const char* filename,
     track->set_id(modelTrack->GetId());
 
     vidtk::track_sptr origTrack;
-    vcl_map<vtkVgTrack*, vidtk::track_sptr>::const_iterator itr =
+    std::map<vtkVgTrack*, vidtk::track_sptr>::const_iterator itr =
       this->TrackMap.find(modelTrack);
     if (itr != this->TrackMap.end())
       {
@@ -221,7 +221,7 @@ bool vpVidtkTrackIO::WriteTracks(const char* filename,
         }
       }
 
-    vcl_vector<vidtk::track_state_sptr>::const_iterator origTrkStateIter,
+    std::vector<vidtk::track_state_sptr>::const_iterator origTrkStateIter,
                                                         origTrkStateEnd;
     if (origTrack)
       {
@@ -386,7 +386,7 @@ bool vpVidtkTrackIO::WriteTracks(const char* filename,
       double lon = 444.0;
       if (orig_state && !orig_state->latitude_longitude(lat, lon))
         {
-        vcl_vector<vidtk::image_object_sptr> objs;
+        std::vector<vidtk::image_object_sptr> objs;
         if (orig_state->data_.get(vidtk::tracking_keys::img_objs, objs))
           {
           const auto& world_loc = objs[0]->get_world_loc();
@@ -410,7 +410,7 @@ bool vpVidtkTrackIO::WriteTracks(const char* filename,
         new_state->vel_ = orig_state->vel_;
         new_state->amhi_bbox_ = orig_state->amhi_bbox_;
 
-        vcl_vector<vidtk::image_object_sptr> objs;
+        std::vector<vidtk::image_object_sptr> objs;
         if (orig_state->data_.get(vidtk::tracking_keys::img_objs, objs))
           {
           obj->set_image_loc(objs[0]->get_image_loc());
@@ -477,11 +477,11 @@ bool vpVidtkTrackIO::WriteTracks(const char* filename,
 }
 
 //-----------------------------------------------------------------------------
-void vpVidtkTrackIO::UpdateTracks(const vcl_vector<vidtk::track_sptr>& tracks,
+void vpVidtkTrackIO::UpdateTracks(const std::vector<vidtk::track_sptr>& tracks,
                                   unsigned int updateStartFrame,
                                   unsigned int updateEndFrame)
 {
-  for (vcl_vector<vidtk::track_sptr>::const_iterator itr = tracks.begin(),
+  for (std::vector<vidtk::track_sptr>::const_iterator itr = tracks.begin(),
        end = tracks.end(); itr != end; ++itr)
     {
     this->ReadTrack(*itr, 0.0f, 0.0f, true, updateStartFrame, updateEndFrame);
@@ -493,7 +493,7 @@ bool vpVidtkTrackIO::GetNextValidTrackFrame(vtkVgTrack* track,
                                             unsigned int startFrame,
                                             vtkVgTimeStamp& timeStamp) const
 {
-  vcl_map<vtkVgTrack*, vidtk::track_sptr>::const_iterator itr =
+  std::map<vtkVgTrack*, vidtk::track_sptr>::const_iterator itr =
     this->TrackMap.find(track);
   if (itr == this->TrackMap.end())
     {
@@ -501,8 +501,8 @@ bool vpVidtkTrackIO::GetNextValidTrackFrame(vtkVgTrack* track,
     }
 
   vidtk::track_sptr vtrack = itr->second;
-  vcl_vector<vidtk::track_state_sptr>::const_iterator iter;
-  vcl_vector<vidtk::track_state_sptr>::const_iterator end =
+  std::vector<vidtk::track_state_sptr>::const_iterator iter;
+  std::vector<vidtk::track_state_sptr>::const_iterator end =
     vtrack->history().end();
 
   // search forwards through the track history until we find the start frame
@@ -525,7 +525,7 @@ bool vpVidtkTrackIO::GetPrevValidTrackFrame(vtkVgTrack* track,
                                             unsigned int startFrame,
                                             vtkVgTimeStamp& timeStamp) const
 {
-  vcl_map<vtkVgTrack*, vidtk::track_sptr>::const_iterator itr =
+  std::map<vtkVgTrack*, vidtk::track_sptr>::const_iterator itr =
     this->TrackMap.find(track);
   if (itr == this->TrackMap.end())
     {
@@ -533,8 +533,8 @@ bool vpVidtkTrackIO::GetPrevValidTrackFrame(vtkVgTrack* track,
     }
 
   vidtk::track_sptr vtrack = itr->second;
-  vcl_vector<vidtk::track_state_sptr>::const_reverse_iterator iter;
-  vcl_vector<vidtk::track_state_sptr>::const_reverse_iterator end
+  std::vector<vidtk::track_state_sptr>::const_reverse_iterator iter;
+  std::vector<vidtk::track_state_sptr>::const_reverse_iterator end
     = vtrack->history().rend();
 
   // search backwards through the track history until we find the start frame
@@ -555,7 +555,7 @@ bool vpVidtkTrackIO::GetPrevValidTrackFrame(vtkVgTrack* track,
 //-----------------------------------------------------------------------------
 vtkIdType vpVidtkTrackIO::GetModelTrackId(unsigned int sourceId) const
 {
-  vcl_map<unsigned int, vtkIdType>::const_iterator itr =
+  std::map<unsigned int, vtkIdType>::const_iterator itr =
     this->SourceIdToModelIdMap.find(sourceId);
 
   if (itr == this->SourceIdToModelIdMap.end())
@@ -624,7 +624,7 @@ void vpVidtkTrackIO::ReadTrack(
                   pvo.get_probability_other());
     }
 
-  const vcl_vector<vidtk::track_state_sptr>& trackHistory =
+  const std::vector<vidtk::track_state_sptr>& trackHistory =
     vidtkTrack->history();
 
   vtkSmartPointer<vtkVgScalars> attrScalars;

--- a/Applications/VpView/vpVidtkTrackIO.h
+++ b/Applications/VpView/vpVidtkTrackIO.h
@@ -18,8 +18,8 @@ class vpVidtkTrackIO : public vpTrackIO
 {
 public:
   vpVidtkTrackIO(vpVidtkReader& reader,
-                 vcl_map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
-                 vcl_map<unsigned int, vtkIdType>& sourceIdToModelIdMap,
+                 std::map<vtkVgTrack*, vidtk::track_sptr>& trackMap,
+                 std::map<unsigned int, vtkIdType>& sourceIdToModelIdMap,
                  vtkVpTrackModel* trackModel,
                  vpTrackIO::TrackStorageMode storageMode,
                  vpTrackIO::TrackTimeStampMode timeStampMode,
@@ -35,7 +35,7 @@ public:
 
   virtual bool WriteTracks(const char* filename, bool writeSceneElements) const;
 
-  void UpdateTracks(const vcl_vector<vidtk::track_sptr>& tracks,
+  void UpdateTracks(const std::vector<vidtk::track_sptr>& tracks,
                     unsigned int updateStartFrame, unsigned int updateEndFrame);
 
   virtual bool GetNextValidTrackFrame(vtkVgTrack* track,
@@ -63,9 +63,9 @@ private:
 
 private:
   vpVidtkReader& Reader;
-  vcl_vector<vidtk::track_sptr> Tracks;
-  vcl_map<vtkVgTrack*, vidtk::track_sptr>& TrackMap;
-  vcl_map<unsigned int, vtkIdType>& SourceIdToModelIdMap;
+  std::vector<vidtk::track_sptr> Tracks;
+  std::map<vtkVgTrack*, vidtk::track_sptr>& TrackMap;
+  std::map<unsigned int, vtkIdType>& SourceIdToModelIdMap;
 };
 
 #endif // __vpVidtkTrackIO_h

--- a/Applications/VpView/vtkVpFileReader.cxx
+++ b/Applications/VpView/vtkVpFileReader.cxx
@@ -65,8 +65,8 @@ bool vtkVpFileReader::GetNextValidTrackFrame(vtkVgTrack* t, vtkIdType startIndex
     return false;
     }
 
-  vcl_vector<vidtk::track_state_sptr>::const_iterator iter;
-  vcl_vector<vidtk::track_state_sptr>::const_iterator end = track->history().end();
+  std::vector<vidtk::track_state_sptr>::const_iterator iter;
+  std::vector<vidtk::track_state_sptr>::const_iterator end = track->history().end();
 
   // search forwards through the track history until we find the start frame
   // or go past
@@ -94,8 +94,8 @@ bool vtkVpFileReader::GetPrevValidTrackFrame(vtkVgTrack* t, vtkIdType startIndex
     return false;
     }
 
-  vcl_vector<vidtk::track_state_sptr>::const_reverse_iterator iter;
-  vcl_vector<vidtk::track_state_sptr>::const_reverse_iterator end
+  std::vector<vidtk::track_state_sptr>::const_reverse_iterator iter;
+  std::vector<vidtk::track_state_sptr>::const_reverse_iterator end
     = track->history().rend();
 
   // search backwards through the track history until we find the start frame
@@ -140,8 +140,8 @@ int vtkVpFileReader::ReadTracks(const char* filename,
     return VTK_ERROR;
     }
 
-  vcl_string fname(filename);
-  vcl_string fext = fname.substr(fname.rfind('.') + 1);
+  std::string fname(filename);
+  std::string fext = fname.substr(fname.rfind('.') + 1);
 
   // Just run this process without making a pipeline (setting one up is probably overkill)
   vidtk::track_reader_process trackReaderProcess("VpFileReader::vtkInternal::ReadTracks");
@@ -167,15 +167,15 @@ int vtkVpFileReader::ReadTracks(const char* filename,
     }
 
   // Look for files containing supplemental track info
-  vcl_string trackTypes(filename);
+  std::string trackTypes(filename);
   trackTypes += ".types";
 
   // Load track types
   if (vtksys::SystemTools::FileExists(trackTypes.c_str(), true))
     {
-    vcl_ifstream file(trackTypes.c_str());
+    std::ifstream file(trackTypes.c_str());
     int id;
-    vcl_string type;
+    std::string type;
     while (file >> id >> type)
       {
       vtkVgTrack* track = this->TrackModel->GetTrack(id);
@@ -199,7 +199,7 @@ int vtkVpFileReader::ReadTracks(const char* filename,
       }
     }
 
-  vcl_string trackRegions(filename);
+  std::string trackRegions(filename);
   trackRegions += ".regions";
 
   // Load polygonal bounding regions
@@ -212,11 +212,11 @@ int vtkVpFileReader::ReadTracks(const char* filename,
       return VTK_OK;
       }
 
-    vcl_ifstream file(trackRegions.c_str());
+    std::ifstream file(trackRegions.c_str());
     int id;
     int frame;
     int numPoints;
-    vcl_vector<float> points;
+    std::vector<float> points;
     bool isKeyFrame;
     while (file >> id >> frame >> isKeyFrame >> numPoints)
       {
@@ -252,7 +252,7 @@ int vtkVpFileReader::ReadTracks(const char* filename,
         }
 
       points.reserve(numPoints * 3);
-      std::back_insert_iterator<vcl_vector<float> > iter(points);
+      std::back_insert_iterator<std::vector<float> > iter(points);
 
       for (int i = 0; i < numPoints; ++i)
         {
@@ -298,7 +298,7 @@ int vtkVpFileReader::ReadTrackTraits(const char* filename)
     return VTK_ERROR;
     }
 
-  vcl_ifstream file(filename);
+  std::ifstream file(filename);
 
   int id;
   double normalcy;
@@ -377,7 +377,7 @@ int vtkVpFileReader::ReadEventLinks(const char* filename)
     return VTK_ERROR;
     }
 
-  vcl_ifstream file(filename);
+  std::ifstream file(filename);
 
   EventLink link;
   while (file >> link.Source >> link.Destination >> link.Probability)
@@ -422,9 +422,9 @@ int vtkVpFileReader::ReadActivities(const char* filename)
 
   // the event manager actually hasthis map, but the reader's need for it should
   // go away, I think, since "ids" are going away "soon"
-  vcl_map<unsigned int, vidtk::event_sptr> eventMap;
+  std::map<unsigned int, vidtk::event_sptr> eventMap;
 
-  vcl_vector<vidtk::event_sptr>::const_iterator eventIter =
+  std::vector<vidtk::event_sptr>::const_iterator eventIter =
     this->InternalBase->Events.begin();
   for (; eventIter != this->InternalBase->Events.end(); eventIter++)
     {

--- a/Libraries/VgVideo/vgKwaFrameMetadata.cxx
+++ b/Libraries/VgVideo/vgKwaFrameMetadata.cxx
@@ -6,13 +6,14 @@
 
 #include "vgKwaFrameMetadata.h"
 
-#include <vcl_vector.h>
 #include <vil/io/vil_io_image_view.h>
 #include <vnl/io/vnl_io_matrix_fixed.h>
 #include <vnl/io/vnl_io_vector_fixed.h>
 #include <vnl/vnl_matrix_fixed.h>
 #include <vsl/vsl_binary_io.h>
 #include <vsl/vsl_vector_io.h>
+
+#include <vector>
 
 const int vgKwaFrameMetadata::SupportedDataVersion = 3;
 
@@ -53,7 +54,7 @@ vgKwaFrameMetadata::vgKwaFrameMetadata(
 
   vxl_int_64 time;
   vnl_matrix_fixed<double, 3, 3> homography;
-  vcl_vector<vnl_vector_fixed<double, 2> > corners;
+  std::vector<vnl_vector_fixed<double, 2> > corners;
 
   vsl_b_read(stream, time);
   if (!isMeta)
@@ -66,7 +67,7 @@ vgKwaFrameMetadata::vgKwaFrameMetadata(
     else
       {
       char imageFormat;
-      vcl_vector<char> imageData;
+      std::vector<char> imageData;
       vsl_b_read(stream, imageFormat);
       vsl_b_read(stream, imageData);
       }

--- a/Libraries/VgVideo/vgKwaVideoClip.cxx
+++ b/Libraries/VgVideo/vgKwaVideoClip.cxx
@@ -16,7 +16,6 @@
 
 #include <vgDebug.h>
 
-#include <vcl_vector.h>
 #include <vil/file_formats/vil_jpeg.h>
 #include <vil/vil_stream_core.h>
 
@@ -27,6 +26,7 @@
 #include <vsl/vsl_vector_io.hxx>
 
 #include <limits>
+#include <vector>
 
 #include "vgIStream.h"
 #include "vgKwaFrameMetadata.h"
@@ -236,7 +236,7 @@ vgImage vgKwaVideoFramePtr::data() const
       }
     vil_stream* memoryStream = new vil_stream_core();
     memoryStream->ref();
-    vcl_vector<char> bytes;
+    std::vector<char> bytes;
     vsl_b_read(*this->dataStream, bytes);
     memoryStream->write(&bytes[0], bytes.size());
     vil_image_resource_sptr imageResource =

--- a/Libraries/VtkVgCore/vtkVgCoordinateTransformUtil.cxx
+++ b/Libraries/VtkVgCore/vtkVgCoordinateTransformUtil.cxx
@@ -19,13 +19,13 @@ vtkSmartPointer<vtkMatrix4x4>
   double geourx, double geoury,
   double geoulx, double geouly)
 {
-  vcl_vector<vgl_homg_point_2d<double> > toPoints;
+  std::vector<vgl_homg_point_2d<double> > toPoints;
   toPoints.push_back(vgl_homg_point_2d<double>(geoulx, geouly, 1));
   toPoints.push_back(vgl_homg_point_2d<double>(geourx, geoury, 1));
   toPoints.push_back(vgl_homg_point_2d<double>(geolrx, geolry, 1));
   toPoints.push_back(vgl_homg_point_2d<double>(geollx, geolly, 1));
 
-  vcl_vector<vgl_homg_point_2d<double> > fromPoints;
+  std::vector<vgl_homg_point_2d<double> > fromPoints;
   fromPoints.push_back(vgl_homg_point_2d<double>(llx, ury, 1.0));
   fromPoints.push_back(vgl_homg_point_2d<double>(urx, ury, 1.0));
   fromPoints.push_back(vgl_homg_point_2d<double>(urx, lly, 1.0));

--- a/Libraries/VtkVgCore/vtkVgVideoFrameMetaData.cxx
+++ b/Libraries/VtkVgCore/vtkVgVideoFrameMetaData.cxx
@@ -126,7 +126,7 @@ vtkVgVideoFrameMetaData::MakeImageToLatLonMatrix() const
     return 0;
     }
 
-  vcl_vector<vgl_homg_point_2d<double> > toPoints;
+  std::vector<vgl_homg_point_2d<double> > toPoints;
   toPoints.push_back(
     vgl_homg_point_2d<double>(this->WorldLocation.UpperLeft.Longitude,
                               this->WorldLocation.UpperLeft.Latitude, 1));
@@ -145,7 +145,7 @@ vtkVgVideoFrameMetaData::MakeImageToLatLonMatrix() const
   double urx = this->Width - 1.0;
   double ury = this->Height - 1.0;
 
-  vcl_vector<vgl_homg_point_2d<double> > fromPoints;
+  std::vector<vgl_homg_point_2d<double> > fromPoints;
   fromPoints.push_back(vgl_homg_point_2d<double>(llx, ury, 1.0));
   fromPoints.push_back(vgl_homg_point_2d<double>(urx, ury, 1.0));
   fromPoints.push_back(vgl_homg_point_2d<double>(urx, lly, 1.0));

--- a/Libraries/VtkVgQtSceneUtil/vtkVgCoordinateTransform.cxx
+++ b/Libraries/VtkVgQtSceneUtil/vtkVgCoordinateTransform.cxx
@@ -101,8 +101,8 @@ void vtkVgCoordinateTransform::SetToPoints(double x1, double y1,
 //-----------------------------------------------------------------------------
 vtkSmartPointer<vtkMatrix4x4> vtkVgCoordinateTransform::GetHomographyMatrix()
 {
-  vcl_vector<vgl_homg_point_2d<double> > fromPoints;
-  vcl_vector<vgl_homg_point_2d<double> > toPoints;
+  std::vector<vgl_homg_point_2d<double> > fromPoints;
+  std::vector<vgl_homg_point_2d<double> > toPoints;
 
   // Add world coordinates to worldPoints
   for (int i = 0; i < 4; ++i)


### PR DESCRIPTION
vcl_ methods were replaced with std:: as is necessary to build with vidtk.