### PR TITLE
Reorder track loading

### DIFF
--- a/Applications/VpView/vpFileTrackIOImpl.cxx
+++ b/Applications/VpView/vpFileTrackIOImpl.cxx
@@ -129,7 +129,6 @@ bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
         }
 
       frameRegion.Points.reserve(numPoints * 3);
-      std::back_insert_iterator<std::vector<float> > iter(frameRegion.Points);
       for (int i = 0; i < numPoints; ++i)
         {
         float x, y;
@@ -138,9 +137,9 @@ bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
           {
           y = io->GetImageHeight() - y - 1;
           }
-        iter = x + offsetX;
-        iter = y + offsetY;
-        iter = 0.0f;
+        frameRegion.Points.push_back(x + offsetX);
+        frameRegion.Points.push_back(y + offsetY);
+        frameRegion.Points.push_back(0.0f);
         }
 
       trackRegionMap[id].emplace(frame, frameRegion);

--- a/Applications/VpView/vpFileTrackIOImpl.cxx
+++ b/Applications/VpView/vpFileTrackIOImpl.cxx
@@ -108,21 +108,13 @@ bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
       }
 
     std::ifstream file(trackRegions.c_str());
-    unsigned int lastId = -1, id;
+    unsigned int id;
     int frame;
     int numPoints;
     bool isKeyFrame;
-    TrackRegions currentTrackMap;
 
     while (file >> id >> frame >> isKeyFrame >> numPoints)
       {
-      if (lastId != -1 && lastId != id)
-        {
-        trackRegionMap.emplace(lastId, currentTrackMap);
-        currentTrackMap.clear();
-        }
-      lastId = id;
-      
       FrameRegionInfo frameRegion;
       frameRegion.KeyFrame = isKeyFrame;
       frameRegion.NumberOfPoints = numPoints;
@@ -132,7 +124,7 @@ bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
         // because we do not insert the point; instead the interpolated points
         // are recalculated.
         file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-        currentTrackMap.emplace(frame, frameRegion);
+        trackRegionMap[id].insert(std::make_pair(frame, frameRegion));
         continue;
         }
 
@@ -151,13 +143,7 @@ bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
         iter = 0.0f;
         }
 
-      currentTrackMap.emplace(frame, frameRegion);
-      }
-
-    // Need to insert the last track map we were working on
-    if (lastId != -1)
-      {
-      trackRegionMap.emplace(frame, currentTrackMap);
+      trackRegionMap[id].emplace(frame, frameRegion);
       }
     }
 

--- a/Applications/VpView/vpFileTrackIOImpl.cxx
+++ b/Applications/VpView/vpFileTrackIOImpl.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -92,7 +92,7 @@ void vpFileTrackIOImpl::ReadTypesFile(vpTrackIO* io,
 bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
                                         const std::string& tracksFileName,
                                         float offsetX, float offsetY,
-                                        TrackRegionMapType* trackRegionMap)
+                                        TrackRegionMap& trackRegionMap)
 {
   std::string trackRegions(tracksFileName);
   trackRegions += ".regions";
@@ -108,17 +108,17 @@ bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
       }
 
     std::ifstream file(trackRegions.c_str());
-    int lastId = -1, id;
+    unsigned int lastId = -1, id;
     int frame;
     int numPoints;
     bool isKeyFrame;
-    std::map<int, FrameRegionInfo> currentTrackMap;
+    TrackRegions currentTrackMap;
 
     while (file >> id >> frame >> isKeyFrame >> numPoints)
       {
       if (lastId != -1 && lastId != id)
         {
-        trackRegionMap->insert(std::make_pair(lastId, currentTrackMap));
+        trackRegionMap.emplace(lastId, currentTrackMap);
         currentTrackMap.clear();
         }
       lastId = id;
@@ -132,7 +132,7 @@ bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
         // because we do not insert the point; instead the interpolated points
         // are recalculated.
         file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-        currentTrackMap.insert(std::make_pair(frame, frameRegion));
+        currentTrackMap.emplace(frame, frameRegion);
         continue;
         }
 
@@ -151,13 +151,13 @@ bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
         iter = 0.0f;
         }
 
-      currentTrackMap.insert(std::make_pair(frame, frameRegion));
+      currentTrackMap.emplace(frame, frameRegion);
       }
 
     // Need to insert the last track map we were working on
     if (lastId != -1)
       {
-      trackRegionMap->insert(std::make_pair(lastId, currentTrackMap));
+      trackRegionMap.emplace(frame, currentTrackMap);
       }
     }
 

--- a/Applications/VpView/vpFileTrackIOImpl.cxx
+++ b/Applications/VpView/vpFileTrackIOImpl.cxx
@@ -125,6 +125,7 @@ bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
       
       FrameRegionInfo frameRegion;
       frameRegion.KeyFrame = isKeyFrame;
+      frameRegion.NumberOfPoints = numPoints;
       if (!isKeyFrame)
         {
         // If this is an interpolated region, we don't need to read the points

--- a/Applications/VpView/vpFileTrackIOImpl.cxx
+++ b/Applications/VpView/vpFileTrackIOImpl.cxx
@@ -48,16 +48,8 @@ bool vpFileTrackIOImpl::ReadTrackTraits(vpTrackIO* io,
 }
 
 //-----------------------------------------------------------------------------
-bool vpFileTrackIOImpl::ReadSupplementalFiles(vpTrackIO* io,
-                                              const std::string& tracksFileName)
-{
-  return ImportSupplementalFiles(io, tracksFileName, 0.0f, 0.0f);
-}
-
-//-----------------------------------------------------------------------------
-bool vpFileTrackIOImpl::ImportSupplementalFiles(vpTrackIO* io,
-                                                const std::string& tracksFileName,
-                                                float offsetX, float offsetY)
+void vpFileTrackIOImpl::ReadTypesFile(vpTrackIO* io,
+                                      const std::string& tracksFileName)
 {
   // Look for files containing supplemental track info
   std::string trackTypes(tracksFileName);
@@ -94,7 +86,15 @@ bool vpFileTrackIOImpl::ImportSupplementalFiles(vpTrackIO* io,
       track->SetColor(color[0], color[1], color[2]);
       }
     }
+}
 
+//-----------------------------------------------------------------------------
+bool vpFileTrackIOImpl::ReadRegionsFile(vpTrackIO* io,
+                                        const std::string& tracksFileName,
+                                        int frameOffset,
+                                        float offsetX/*=0*/,
+                                        float offsetY/*=0*/)
+{
   std::string trackRegions(tracksFileName);
   trackRegions += ".regions";
 
@@ -166,6 +166,7 @@ bool vpFileTrackIOImpl::ImportSupplementalFiles(vpTrackIO* io,
                   << ts.GetFrameNumber() << '\n';
         continue;
         }
+
 
       track->SetPoint(ts, point, track->GetGeoCoord(ts), numPoints, &points[0]);
       points.clear();

--- a/Applications/VpView/vpFileTrackIOImpl.h
+++ b/Applications/VpView/vpFileTrackIOImpl.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,8 +7,8 @@
 #ifndef __vpFileTrackIOImpl_h
 #define __vpFileTrackIOImpl_h
 
-#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class vpTrackIO;
@@ -23,8 +23,8 @@ public:
     std::vector<float> Points;
     };
 
-  typedef std::map<int, std::map<int, FrameRegionInfo> > TrackRegionMapType;
-  TrackRegionMapType TrackRegionMap;
+  using TrackRegions = std::unordered_map<unsigned int, FrameRegionInfo>;
+  using TrackRegionMap = std::unordered_map<unsigned int, TrackRegions>;
 
   static bool ReadTrackTraits(vpTrackIO* io,
                               const std::string& trackTraitsFileName);
@@ -32,7 +32,7 @@ public:
   static bool ReadRegionsFile(vpTrackIO* io,
                               const std::string& tracksFileName,
                               float offsetX, float offsetY,
-                              TrackRegionMapType* trackRegionMap);
+                              TrackRegionMap& trackRegionMap);
 
   static void ReadTypesFile(vpTrackIO* io, const std::string& tracksFileName);
 };

--- a/Applications/VpView/vpFileTrackIOImpl.h
+++ b/Applications/VpView/vpFileTrackIOImpl.h
@@ -19,6 +19,7 @@ public:
   struct FrameRegionInfo
     {
     bool KeyFrame;
+    int NumberOfPoints;
     std::vector<float> Points;
     };
 

--- a/Applications/VpView/vpFileTrackIOImpl.h
+++ b/Applications/VpView/vpFileTrackIOImpl.h
@@ -7,20 +7,31 @@
 #ifndef __vpFileTrackIOImpl_h
 #define __vpFileTrackIOImpl_h
 
+#include <map>
 #include <string>
+#include <vector>
 
 class vpTrackIO;
 
 class vpFileTrackIOImpl
 {
 public:
+  struct FrameRegionInfo
+    {
+    bool KeyFrame;
+    std::vector<float> Points;
+    };
+
+  typedef std::map<int, std::map<int, FrameRegionInfo> > TrackRegionMapType;
+  TrackRegionMapType TrackRegionMap;
+
   static bool ReadTrackTraits(vpTrackIO* io,
                               const std::string& trackTraitsFileName);
 
   static bool ReadRegionsFile(vpTrackIO* io,
                               const std::string& tracksFileName,
-                              int frameOffset,
-                              float offsetX = 0.0f, float offsetY = 0.0f);
+                              float offsetX, float offsetY,
+                              TrackRegionMapType* trackRegionMap);
 
   static void ReadTypesFile(vpTrackIO* io, const std::string& tracksFileName);
 };

--- a/Applications/VpView/vpFileTrackIOImpl.h
+++ b/Applications/VpView/vpFileTrackIOImpl.h
@@ -17,12 +17,12 @@ public:
   static bool ReadTrackTraits(vpTrackIO* io,
                               const std::string& trackTraitsFileName);
 
-  static bool ReadSupplementalFiles(vpTrackIO* io,
-                                    const std::string& tracksFileName);
+  static bool ReadRegionsFile(vpTrackIO* io,
+                              const std::string& tracksFileName,
+                              int frameOffset,
+                              float offsetX = 0.0f, float offsetY = 0.0f);
 
-  static bool ImportSupplementalFiles(vpTrackIO* io,
-                                      const std::string& tracksFileName,
-                                      float offsetX, float offsetY);
+  static void ReadTypesFile(vpTrackIO* io, const std::string& tracksFileName);
 };
 
 #endif // __vpFileTrackIOImpl_h

--- a/Applications/VpView/vpVidtkFileTrackIO.cxx
+++ b/Applications/VpView/vpVidtkFileTrackIO.cxx
@@ -28,15 +28,18 @@ vpVidtkFileTrackIO::vpVidtkFileTrackIO(
 //-----------------------------------------------------------------------------
 bool vpVidtkFileTrackIO::ReadTracks()
 {
-  if (!vpVidtkTrackIO::ReadTracks())
+  std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
+    this->GetReader()).GetTracksFileName();
+
+  vpFileTrackIOImpl::TrackRegionMapType trackRegionMap;
+  vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, 0.0f, 0.0f,
+                                     &trackRegionMap);
+
+  if (!vpVidtkTrackIO::ReadTracks(&trackRegionMap))
     {
     return false;
     }
 
-  std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
-    this->GetReader()).GetTracksFileName();
-
-  vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, frameOffset);
   vpFileTrackIOImpl::ReadTypesFile(this, tracksFileName);
 
   return true;
@@ -46,16 +49,18 @@ bool vpVidtkFileTrackIO::ReadTracks()
 bool vpVidtkFileTrackIO::ImportTracks(vtkIdType idsOffset,
                                       float offsetX, float offsetY)
 {
+  std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
+    this->GetReader()).GetTracksFileName();
+  vpFileTrackIOImpl::TrackRegionMapType trackRegionMap;
+  vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, offsetX, offsetY,
+                                     &trackRegionMap);
+
   if (!vpVidtkTrackIO::ImportTracks(idsOffset, offsetX, offsetY))
     {
     return false;
     }
-  std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
-    this->GetReader()).GetTracksFileName();
 
   vpFileTrackIOImpl::ReadTypesFile(this, tracksFileName);
-  vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, frameOffset,
-                                     offsetX, offsetY);
 
   return true;
 }

--- a/Applications/VpView/vpVidtkFileTrackIO.cxx
+++ b/Applications/VpView/vpVidtkFileTrackIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -31,9 +31,9 @@ bool vpVidtkFileTrackIO::ReadTracks()
   std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
     this->GetReader()).GetTracksFileName();
 
-  vpFileTrackIOImpl::TrackRegionMapType trackRegionMap;
+  vpFileTrackIOImpl::TrackRegionMap trackRegionMap;
   vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, 0.0f, 0.0f,
-                                     &trackRegionMap);
+                                     trackRegionMap);
 
   if (!vpVidtkTrackIO::ReadTracks(&trackRegionMap))
     {
@@ -51,9 +51,10 @@ bool vpVidtkFileTrackIO::ImportTracks(vtkIdType idsOffset,
 {
   std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
     this->GetReader()).GetTracksFileName();
-  vpFileTrackIOImpl::TrackRegionMapType trackRegionMap;
+
+  vpFileTrackIOImpl::TrackRegionMap trackRegionMap;
   vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, offsetX, offsetY,
-                                     &trackRegionMap);
+                                     trackRegionMap);
 
   if (!vpVidtkTrackIO::ImportTracks(idsOffset, offsetX, offsetY))
     {

--- a/Applications/VpView/vpVidtkFileTrackIO.cxx
+++ b/Applications/VpView/vpVidtkFileTrackIO.cxx
@@ -32,9 +32,13 @@ bool vpVidtkFileTrackIO::ReadTracks()
     {
     return false;
     }
-  vpFileTrackIOImpl::ReadSupplementalFiles(
-    this, static_cast<const vpVidtkFileReader&>(
-            this->GetReader()).GetTracksFileName());
+
+  std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
+    this->GetReader()).GetTracksFileName();
+
+  vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, frameOffset);
+  vpFileTrackIOImpl::ReadTypesFile(this, tracksFileName);
+
   return true;
 }
 
@@ -46,10 +50,13 @@ bool vpVidtkFileTrackIO::ImportTracks(vtkIdType idsOffset,
     {
     return false;
     }
-  vpFileTrackIOImpl::ImportSupplementalFiles(
-    this,
-    static_cast<const vpVidtkFileReader&>(this->GetReader()).GetTracksFileName(),
-    offsetX, offsetY);
+  std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
+    this->GetReader()).GetTracksFileName();
+
+  vpFileTrackIOImpl::ReadTypesFile(this, tracksFileName);
+  vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, frameOffset,
+                                     offsetX, offsetY);
+
   return true;
 }
 

--- a/Applications/VpView/vpVidtkFileTrackIO.cxx
+++ b/Applications/VpView/vpVidtkFileTrackIO.cxx
@@ -28,8 +28,8 @@ vpVidtkFileTrackIO::vpVidtkFileTrackIO(
 //-----------------------------------------------------------------------------
 bool vpVidtkFileTrackIO::ReadTracks()
 {
-  std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
-    this->GetReader()).GetTracksFileName();
+  auto& reader = static_cast<const vpVidtkFileReader&>(this->GetReader());
+  const auto& tracksFileName = reader.GetTracksFileName();
 
   vpFileTrackIOImpl::TrackRegionMap trackRegionMap;
   vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, 0.0f, 0.0f,
@@ -49,8 +49,8 @@ bool vpVidtkFileTrackIO::ReadTracks()
 bool vpVidtkFileTrackIO::ImportTracks(vtkIdType idsOffset,
                                       float offsetX, float offsetY)
 {
-  std::string tracksFileName = static_cast<const vpVidtkFileReader&>(
-    this->GetReader()).GetTracksFileName();
+  auto& reader = static_cast<const vpVidtkFileReader&>(this->GetReader());
+  const auto& tracksFileName = reader.GetTracksFileName();
 
   vpFileTrackIOImpl::TrackRegionMap trackRegionMap;
   vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, offsetX, offsetY,

--- a/Applications/VpView/vpVidtkFileTrackIO.cxx
+++ b/Applications/VpView/vpVidtkFileTrackIO.cxx
@@ -56,7 +56,8 @@ bool vpVidtkFileTrackIO::ImportTracks(vtkIdType idsOffset,
   vpFileTrackIOImpl::ReadRegionsFile(this, tracksFileName, offsetX, offsetY,
                                      trackRegionMap);
 
-  if (!vpVidtkTrackIO::ImportTracks(idsOffset, offsetX, offsetY))
+  if (!vpVidtkTrackIO::ImportTracks(&trackRegionMap, idsOffset,
+                                    offsetX, offsetY))
     {
     return false;
     }

--- a/Applications/VpView/vpVidtkTrackIO.cxx
+++ b/Applications/VpView/vpVidtkTrackIO.cxx
@@ -807,8 +807,8 @@ void vpVidtkTrackIO::ReadTrack(
         if (this->StorageMode == TSM_HomographyTransformedImageCoords)
           {
           // we expect there to be a homography for every frame
-          if (!this->FrameMap->getFrame(frame_number,
-               frameMetaData) || !frameMetaData.Homography)
+          if (!this->FrameMap->getFrame(frame_number, frameMetaData) ||
+              !frameMetaData.Homography)
             {
             std::cerr << "ERROR: Homography for frame # "
               << frame_number
@@ -856,14 +856,14 @@ void vpVidtkTrackIO::ReadTrack(
         const float* shellPoints = bbox;
 
         if (this->StorageMode == TSM_HomographyTransformedImageCoords &&
-          frameMetaData.Homography)
+            frameMetaData.Homography)
           {
           const float* inputPoints = bbox;
           if (matchingFrame)
             {
             numPoints = matchingFrame->NumberOfPoints;
             points.reserve(matchingFrame->Points.size());
-            inputPoints = &matchingFrame->Points[0];
+            inputPoints = matchingFrame->Points.data();
             }
 
           for (int i = 0; i < numPoints; ++i, inputPoints += 3)
@@ -874,13 +874,13 @@ void vpVidtkTrackIO::ReadTrack(
             points.push_back(static_cast<float>(pt[1]) + offsetY);
             points.push_back(0.0f);
             }
-          shellPoints = &points[0];
+          shellPoints = points.data();
           }
         else
           {
           if (matchingFrame)
             {
-            shellPoints = &matchingFrame->Points[0];
+            shellPoints = matchingFrame->Points.data();
             numPoints = matchingFrame->NumberOfPoints;
             }
           }

--- a/Applications/VpView/vpVidtkTrackIO.cxx
+++ b/Applications/VpView/vpVidtkTrackIO.cxx
@@ -174,6 +174,14 @@ bool vpVidtkTrackIO::ReadTracks(
 bool vpVidtkTrackIO::ImportTracks(vtkIdType idsOffset,
                                   float offsetX, float offsetY)
 {
+  return this->ImportTracks(nullptr, idsOffset, offsetX, offsetY);
+}
+
+//-----------------------------------------------------------------------------
+bool vpVidtkTrackIO::ImportTracks(
+  const vpFileTrackIOImpl::TrackRegionMap* trackRegionMap,
+  vtkIdType idsOffset, float offsetX, float offsetY)
+{
   assert(this->StorageMode != TSM_TransformedGeoCoords ||
          this->GeoTransform);
   assert(this->StorageMode != TSM_InvertedImageCoords ||
@@ -187,8 +195,8 @@ bool vpVidtkTrackIO::ImportTracks(vtkIdType idsOffset,
 
   for (size_t i = prevTracksSize, size = this->Tracks.size(); i < size; ++i)
     {
-    this->ReadTrack(this->Tracks[i], nullptr, offsetX, offsetY, false, 0,
-                    0, idsOffset + this->Tracks[i]->id());
+    this->ReadTrack(this->Tracks[i], trackRegionMap, offsetX, offsetY, false,
+                    0, 0, idsOffset + this->Tracks[i]->id());
     }
 
   return true;

--- a/Applications/VpView/vpVidtkTrackIO.cxx
+++ b/Applications/VpView/vpVidtkTrackIO.cxx
@@ -866,14 +866,13 @@ void vpVidtkTrackIO::ReadTrack(
             inputPoints = &matchingFrame->Points[0];
             }
 
-          std::back_insert_iterator<std::vector<float> > iter(points);
           for (int i = 0; i < numPoints; ++i, inputPoints += 3)
             {
             double pt[2] = {*inputPoints, *(inputPoints + 1)};
             vtkVgApplyHomography(pt, frameMetaData.Homography, pt);
-            iter = static_cast<float>(pt[0]) + offsetX;
-            iter = static_cast<float>(pt[1]) + offsetY;
-            iter = 0.0f;
+            points.push_back(static_cast<float>(pt[0]) + offsetX);
+            points.push_back(static_cast<float>(pt[1]) + offsetY);
+            points.push_back(0.0f);
             }
           shellPoints = &points[0];
           }

--- a/Applications/VpView/vpVidtkTrackIO.cxx
+++ b/Applications/VpView/vpVidtkTrackIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -49,12 +49,12 @@ vpVidtkTrackIO::~vpVidtkTrackIO()
 //-----------------------------------------------------------------------------
 bool vpVidtkTrackIO::ReadTracks()
 {
-  return this->ReadTracks(0);
+  return this->ReadTracks(nullptr);
 }
 
 //-----------------------------------------------------------------------------
 vtkIdType vpVidtkTrackIO::ComputeNumberOfPoints(
-  const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap)
+  const vpFileTrackIOImpl::TrackRegionMap* trackRegionMap)
 {
   vtkIdType numberOfRegionPoints = 0, numberOfTrackPoints = 0;
   for (size_t i = 0, size = this->Tracks.size(); i < size; ++i)
@@ -68,8 +68,8 @@ vtkIdType vpVidtkTrackIO::ComputeNumberOfPoints(
       static_cast<vtkIdType>(history.back()->time_.frame_number() -
       history.front()->time_.frame_number() + 1);
 
-    vpFileTrackIOImpl::TrackRegionMapType::const_iterator matchingTrackIter;
-    const std::map<int, vpFileTrackIOImpl::FrameRegionInfo>* matchingTrack = 0;
+    vpFileTrackIOImpl::TrackRegionMap::const_iterator matchingTrackIter;
+    const vpFileTrackIOImpl::TrackRegions* matchingTrack = nullptr;
     if (trackRegionMap &&
       (matchingTrackIter = trackRegionMap->find(this->Tracks[i]->id())) !=
       trackRegionMap->end())
@@ -92,7 +92,7 @@ vtkIdType vpVidtkTrackIO::ComputeNumberOfPoints(
         trkStateIter++)
         {
         unsigned int frame_number = (*trkStateIter)->time_.frame_number();
-        std::map<int, vpFileTrackIOImpl::FrameRegionInfo>::const_iterator
+        vpFileTrackIOImpl::TrackRegions::const_iterator
           matchingFrameIter;
         if (matchingTrack &&
           (matchingFrameIter = matchingTrack->find(frame_number)) !=
@@ -113,7 +113,7 @@ vtkIdType vpVidtkTrackIO::ComputeNumberOfPoints(
 
 //-----------------------------------------------------------------------------
 bool vpVidtkTrackIO::ReadTracks(
-  const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap)
+  const vpFileTrackIOImpl::TrackRegionMap* trackRegionMap)
 {
   assert(this->StorageMode != TSM_TransformedGeoCoords ||
          this->GeoTransform);
@@ -159,7 +159,7 @@ bool vpVidtkTrackIO::ImportTracks(vtkIdType idsOffset,
 
   for (size_t i = prevTracksSize, size = this->Tracks.size(); i < size; ++i)
     {
-    this->ReadTrack(this->Tracks[i], 0, offsetX, offsetY, false, 0,
+    this->ReadTrack(this->Tracks[i], nullptr, offsetX, offsetY, false, 0,
                     0, idsOffset + this->Tracks[i]->id());
     }
 
@@ -529,8 +529,8 @@ void vpVidtkTrackIO::UpdateTracks(const std::vector<vidtk::track_sptr>& tracks,
   for (std::vector<vidtk::track_sptr>::const_iterator itr = tracks.begin(),
        end = tracks.end(); itr != end; ++itr)
     {
-    this->ReadTrack(*itr, 0, 0.0f, 0.0f, true, updateStartFrame,
-                    updateEndFrame);
+    this->ReadTrack(*itr, nullptr, 0.0f, 0.0f, true,
+                    updateStartFrame, updateEndFrame);
     }
 }
 
@@ -621,7 +621,7 @@ unsigned int vpVidtkTrackIO::GetImageHeight() const
 //-----------------------------------------------------------------------------
 void vpVidtkTrackIO::ReadTrack(
   const vidtk::track_sptr vidtkTrack,
-  const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap,
+  const vpFileTrackIOImpl::TrackRegionMap* trackRegionMap,
   float offsetX, float offsetY,
   bool update, unsigned int updateStartFrame, unsigned int updateEndFrame,
   vtkIdType desiredId)
@@ -663,8 +663,8 @@ void vpVidtkTrackIO::ReadTrack(
     newTrack = true;
     }
 
-  vpFileTrackIOImpl::TrackRegionMapType::const_iterator matchingTrackIter;
-  const std::map<int, vpFileTrackIOImpl::FrameRegionInfo>* matchingTrack = 0;
+  vpFileTrackIOImpl::TrackRegionMap::const_iterator matchingTrackIter;
+  const vpFileTrackIOImpl::TrackRegions* matchingTrack = nullptr;
   if (trackRegionMap &&
       (matchingTrackIter = trackRegionMap->find(desiredId)) !=
        trackRegionMap->end())
@@ -719,9 +719,9 @@ void vpVidtkTrackIO::ReadTrack(
     {
     unsigned int frame_number = (*trkStateIter)->time_.frame_number();
 
-    std::map<int, vpFileTrackIOImpl::FrameRegionInfo>::const_iterator
+    vpFileTrackIOImpl::TrackRegions::const_iterator
       matchingFrameIter;
-    const vpFileTrackIOImpl::FrameRegionInfo* matchingFrame = 0;
+    const vpFileTrackIOImpl::FrameRegionInfo* matchingFrame = nullptr;
     if (matchingTrack &&
         (matchingFrameIter = matchingTrack->find(frame_number)) !=
          matchingTrack->end())

--- a/Applications/VpView/vpVidtkTrackIO.h
+++ b/Applications/VpView/vpVidtkTrackIO.h
@@ -53,6 +53,9 @@ public:
 protected:
   bool ReadTracks(const vpFileTrackIOImpl::TrackRegionMap* trackRegionMap);
 
+  bool ImportTracks(const vpFileTrackIOImpl::TrackRegionMap* trackRegionMap,
+                    vtkIdType idsOffset, float offsetX, float offsetY);
+
   const vpVidtkReader& GetReader() const { return this->Reader; }
 
   virtual unsigned int GetImageHeight() const;

--- a/Applications/VpView/vpVidtkTrackIO.h
+++ b/Applications/VpView/vpVidtkTrackIO.h
@@ -9,6 +9,8 @@
 
 #include "vpTrackIO.h"
 
+#include "vpFileTrackIOImpl.h"
+
 #include <tracking_data/track.h>
 
 class vpVidtkReader;
@@ -49,12 +51,15 @@ public:
   virtual vtkIdType GetModelTrackId(unsigned int sourceId) const;
 
 protected:
+  bool ReadTracks(const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap);
+
   const vpVidtkReader& GetReader() const { return this->Reader; }
 
   virtual unsigned int GetImageHeight() const;
 
 private:
   void ReadTrack(const vidtk::track_sptr vidtkTrack,
+                 const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap,
                  float offsetX = 0.0f, float offsetY = 0.0f,
                  bool update = false,
                  unsigned int updateStartFrame = 0,

--- a/Applications/VpView/vpVidtkTrackIO.h
+++ b/Applications/VpView/vpVidtkTrackIO.h
@@ -58,6 +58,8 @@ protected:
   virtual unsigned int GetImageHeight() const;
 
 private:
+  vtkIdType ComputeNumberOfPoints(
+    const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap);
   void ReadTrack(const vidtk::track_sptr vidtkTrack,
                  const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap,
                  float offsetX = 0.0f, float offsetY = 0.0f,

--- a/Applications/VpView/vpVidtkTrackIO.h
+++ b/Applications/VpView/vpVidtkTrackIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -51,7 +51,7 @@ public:
   virtual vtkIdType GetModelTrackId(unsigned int sourceId) const;
 
 protected:
-  bool ReadTracks(const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap);
+  bool ReadTracks(const vpFileTrackIOImpl::TrackRegionMap* trackRegionMap);
 
   const vpVidtkReader& GetReader() const { return this->Reader; }
 
@@ -59,9 +59,9 @@ protected:
 
 private:
   vtkIdType ComputeNumberOfPoints(
-    const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap);
+    const vpFileTrackIOImpl::TrackRegionMap* trackRegionMap);
   void ReadTrack(const vidtk::track_sptr vidtkTrack,
-                 const vpFileTrackIOImpl::TrackRegionMapType* trackRegionMap,
+                 const vpFileTrackIOImpl::TrackRegionMap* trackRegionMap,
                  float offsetX = 0.0f, float offsetY = 0.0f,
                  bool update = false,
                  unsigned int updateStartFrame = 0,

--- a/Libraries/VtkVgCore/vtkVgTrack.cxx
+++ b/Libraries/VtkVgCore/vtkVgTrack.cxx
@@ -77,7 +77,7 @@ public:
   void SetHeadIdentifier(const vtkVgTimeStamp& timestamp,
                          vtkPoints* points, vtkIdType numberOfPts,
                          vtkPoints* fromPoints, vtkIdType fromPtsStart,
-                         float* pts = 0)
+                         const float* pts = 0)
     {
     this->HeadIdentifierStartIndex[timestamp] =
       this->HeadIdentifierIds->GetNumberOfIds();
@@ -388,10 +388,10 @@ void vtkVgTrack::InsertNextPoint(const vtkVgTimeStamp& timeStamp,
                                  double point[2],
                                  const vtkVgGeoCoord& geoCoord,
                                  vtkIdType numberOfShellPts,
-                                 float* shellPts,
+                                 const float* shellPts,
+                                 bool interpolateShell,
                                  vtkPoints* fromShellPoints,
-                                 vtkIdType fromShellPtsStart,
-                                 bool interpolateShell)
+                                 vtkIdType fromShellPtsStart)
 {
   if (!this->Points)
     {
@@ -485,7 +485,7 @@ void vtkVgTrack::AddInterpolationPoints(const vtkVgTimeStamp& previousTimeStamp,
                                         vtkIdType numShellPts,
                                         vtkPoints* fromShellPts,
                                         vtkIdType fromShellPtsStart,
-                                        float* shellPts, bool warnOnFailure)
+                                        const float* shellPts, bool warnOnFailure)
 {
   vtkIdType numFrames;
   if (timeStamp.HasTime())
@@ -563,7 +563,7 @@ void vtkVgTrack::AddInterpolationPoints(const vtkVgTimeStamp& previousTimeStamp,
       float tempPt[3];
       for (vtkIdType p = 0; p < numShellPts; ++p)
         {
-        float* shellPt;
+        const float* shellPt;
         if (fromShellPts)
           {
           double* pt = fromShellPts->GetPoint(fromShellPtsStart + p);
@@ -609,7 +609,7 @@ void vtkVgTrack::AddInterpolationPoints(const vtkVgTimeStamp& previousTimeStamp,
 //-----------------------------------------------------------------------------
 void vtkVgTrack::SetPoint(const vtkVgTimeStamp& timeStamp, double point[2],
                           vtkVgGeoCoord geoCoord,
-                          vtkIdType numberOfShellPts, float* shellPts,
+                          vtkIdType numberOfShellPts, const float* shellPts,
                           vtkPoints* fromShellPts,
                           vtkIdType fromShellPtsStart)
 {
@@ -619,8 +619,8 @@ void vtkVgTrack::SetPoint(const vtkVgTimeStamp& timeStamp, double point[2],
        timeStamp > this->Internal->PointIdMap.rbegin()->first))
     {
     this->InsertNextPoint(timeStamp, point, geoCoord,
-                          numberOfShellPts, shellPts,
-                          fromShellPts, fromShellPtsStart, true);
+                          numberOfShellPts, shellPts, true,
+                          fromShellPts, fromShellPtsStart);
     return;
     }
 

--- a/Libraries/VtkVgCore/vtkVgTrack.h
+++ b/Libraries/VtkVgCore/vtkVgTrack.h
@@ -99,10 +99,10 @@ public:
   void InsertNextPoint(const vtkVgTimeStamp& timeStamp, double point[2],
                        const vtkVgGeoCoord& geoCoord,
                        vtkIdType numberOfShellPts,
-                       float* shellPts,
+                       const float* shellPts,
+                       bool interpolateShell = false,
                        vtkPoints* fromShellPoints = 0,
-                       vtkIdType fromShellPtsStart = -1,
-                       bool interpolateShell = false);
+                       vtkIdType fromShellPtsStart = -1);
 
   // Description:
   // Wrapper around InsertNextPoint to facilitate python wrapping by using a
@@ -120,7 +120,7 @@ public:
   // data will be used.
   void SetPoint(const vtkVgTimeStamp& timeStamp, double point[2],
                 vtkVgGeoCoord geoCoord,
-                vtkIdType numberOfShellPts = 0, float* shellPts = 0,
+                vtkIdType numberOfShellPts = 0, const float* shellPts = 0,
                 vtkPoints* fromShellPts = 0, vtkIdType fromShellPtsStart = -1);
 
   // Description:
@@ -368,7 +368,7 @@ private:
                               vtkIdType numShellPts,
                               vtkPoints* fromShellPts,
                               vtkIdType fromShellPtsStart,
-                              float* shellPts = 0,
+                              const float* shellPts = 0,
                               bool warnOnFailure = true);
 
   void BuildAllPointsIdMap(const vtkVgTimeStamp& timeStamp,


### PR DESCRIPTION
Loading of annotated tracks, specifically those that required a .regions file with a relatively large # of interpolated states has been very inefficient, especially from the standpoint of memory usage - we have an example of a 60 MB kw18 file that consumes roughly 2 GB of memory (in track oracle) requires an additional ~6 GB to load into vivia. This was because we loaded all the states from the kw18 and then would read the regions file to remove the states loaded via kw18 that were interpolated, one at a time (this was done for a variety of reasons, but internally we need to know which state are key frames and it isn't as simple as marking with a flag) . Each time a key frame is removed, all frames between key frames are (re)computed... thus having 100 interpolated states between two key frames means a couple thousand wasted points: they are all originally key states; remove first key frame (because it is interpolated) which is then automatically interpolated; remove next key frame (that is an interpolated state) and we then automatically interpolate two states (we reinterpolate the first one); etc... etc.

This branch loads the region file first, and then uses those as we convert the track info (from kw18) into vivia to do it more efficiently (interpolated frames are never manually inserted; only key frames are).

As a result, the same example mentioned earlier reduces the vivia requirement to be "negligible" compared to the track oracle footprint; 2 GB + < 0.5 GB vivia rep.