### PR TITLE
Use track_oracle data terms

### DIFF
--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/CMakeLists.txt
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/CMakeLists.txt
@@ -35,6 +35,7 @@ if(TARGET kwiver::track_oracle)
   target_link_libraries(${PROJECT_NAME}
     kwiver::track_oracle
     kwiver::track_oracle_file_formats
+    kwiver::vital
   )
 else()
   target_link_libraries(${PROJECT_NAME}

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/track_oracle_utils.h
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/track_oracle_utils.h
@@ -29,18 +29,9 @@ namespace track_oracle
 #else
   using namespace vidtk;
 #endif
-
-  template <typename T>
-  struct track_field_type;
-
-  template <typename T>
-  struct track_field_type<::track_oracle::track_field<T>&>
-  {
-    using type = T;
-  };
 }
 
-#define TRACK_ORACLE_INIT_FIELD(t, n) \
-  n(t.add_field<::track_oracle::track_field_type<decltype(n)>::type>(#n))
+#define TRACK_ORACLE_FIELD(ns, name) \
+  ::track_oracle::track_field<::track_oracle::dt::ns::name> name
 
 #endif

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/vdfTrackOracleTrackArchiveSource.cxx
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/vdfTrackOracleTrackArchiveSource.cxx
@@ -162,6 +162,7 @@ bool vdfTrackOracleTrackDataSource::processArchive(const QUrl& uri)
     missingFields.remove(fieldName(schema.bounding_box));
     missingFields.remove(fieldName(schema.obj_location));
     missingFields.remove(fieldName(schema.world_location));
+    missingFields.remove(fieldName(schema.world_gcs));
 
     // Check if any mandatory fields are missing
     if (!missingFields.empty())
@@ -260,6 +261,10 @@ bool vdfTrackOracleTrackDataSource::processArchive(const QUrl& uri)
             const vgl_point_3d<double>& p = oracle.world_location();
             state.WorldLocation =
               vgGeocodedCoordinate(p.y(), p.x(), vgGeodesy::LatLon_Wgs84);
+            if (oracle.world_gcs.exists() && oracle.world_gcs() > 0)
+              {
+              state.WorldLocation.GCS = oracle.world_gcs();
+              }
             }
 
           // Add state

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/visgui_track_type.h
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/visgui_track_type.h
@@ -47,6 +47,7 @@ struct visgui_track_type :
 
   TRACK_ORACLE_FIELD(tracking, frame_number);
   TRACK_ORACLE_FIELD(tracking, world_location);
+  TRACK_ORACLE_FIELD(tracking, world_gcs);
 
   visgui_track_type()
     {
@@ -54,6 +55,7 @@ struct visgui_track_type :
 
     Frame.add_field(frame_number);
     Frame.add_field(world_location);
+    Frame.add_field(world_gcs);
     }
 };
 

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/visgui_track_type.h
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/visgui_track_type.h
@@ -17,29 +17,25 @@
 #include <track_oracle/track_field.h>
 #endif
 
-#include <vgl/vgl_box_2d.h>
-#include <vgl/vgl_point_2d.h>
-#include <vgl/vgl_point_3d.h>
-
-#include <boost/uuid/uuid.hpp>
+#include <track_oracle/data_terms/data_terms.h>
 
 //-----------------------------------------------------------------------------
 struct visgui_minimal_track_type :
   public track_oracle::track_base<visgui_minimal_track_type>
 {
-  track_oracle::track_field<unsigned int>& external_id;
+  TRACK_ORACLE_FIELD(tracking, external_id);
 
-  track_oracle::track_field<unsigned long long>& timestamp_usecs;
-  track_oracle::track_field<vgl_box_2d<double> >& bounding_box;
-  track_oracle::track_field<vgl_point_2d<double> >& obj_location;
+  TRACK_ORACLE_FIELD(tracking, timestamp_usecs);
+  TRACK_ORACLE_FIELD(tracking, bounding_box);
+  TRACK_ORACLE_FIELD(tracking, obj_location);
 
-  visgui_minimal_track_type() :
-    TRACK_ORACLE_INIT_FIELD(Track, external_id),
-
-    TRACK_ORACLE_INIT_FIELD(Frame, timestamp_usecs),
-    TRACK_ORACLE_INIT_FIELD(Frame, bounding_box),
-    TRACK_ORACLE_INIT_FIELD(Frame, obj_location)
+  visgui_minimal_track_type()
     {
+    Track.add_field(external_id);
+
+    Frame.add_field(timestamp_usecs);
+    Frame.add_field(bounding_box);
+    Frame.add_field(obj_location);
     }
 };
 
@@ -47,22 +43,17 @@ struct visgui_minimal_track_type :
 struct visgui_track_type :
   public track_oracle::track_base<visgui_track_type, visgui_minimal_track_type>
 {
-#ifndef KWIVER_TRACK_ORACLE
-  // TODO: Reenable this when UUID's are supported by KWIVER's track_oracle
-  track_oracle::track_field<boost::uuids::uuid>& unique_id;
-#endif
+  TRACK_ORACLE_FIELD(tracking, track_uuid);
 
-  track_oracle::track_field<unsigned>& frame_number;
-  track_oracle::track_field<vgl_point_3d<double> >& world_location;
+  TRACK_ORACLE_FIELD(tracking, frame_number);
+  TRACK_ORACLE_FIELD(tracking, world_location);
 
-  visgui_track_type() :
-#ifndef KWIVER_TRACK_ORACLE
-    TRACK_ORACLE_INIT_FIELD(Track, unique_id),
-#endif
-
-    TRACK_ORACLE_INIT_FIELD(Frame, frame_number),
-    TRACK_ORACLE_INIT_FIELD(Frame, world_location)
+  visgui_track_type()
     {
+    Track.add_field(track_uuid);
+
+    Frame.add_field(frame_number);
+    Frame.add_field(world_location);
     }
 };
 

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/track_oracle_utils.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/track_oracle_utils.h
@@ -40,6 +40,9 @@ namespace track_oracle
   };
 }
 
+#define TRACK_ORACLE_FIELD(ns, name) \
+  ::track_oracle::track_field<::track_oracle::dt::ns::name> name
+
 #define TRACK_ORACLE_INIT_FIELD(t, n) \
   n(t.add_field<::track_oracle::track_field_type<decltype(n)>::type>(#n))
 

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/visgui_track_type.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/visgui_track_type.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -17,22 +17,23 @@
 #include <track_oracle/track_field.h>
 #endif
 
-#include <vgl/vgl_box_2d.h>
-#include <vgl/vgl_point_2d.h>
+#include <track_oracle/data_terms/data_terms.h>
 
 //-----------------------------------------------------------------------------
 struct visgui_base_track_type :
   public track_oracle::track_base<visgui_base_track_type>
 {
-  track_oracle::track_field<unsigned int>& external_id;
-  track_oracle::track_field<vgl_point_2d<double>>& obj_location;
-  track_oracle::track_field<vgl_box_2d<double>>& bounding_box;
+  TRACK_ORACLE_FIELD(tracking, external_id);
 
-  visgui_base_track_type() :
-    TRACK_ORACLE_INIT_FIELD(Track, external_id),
-    TRACK_ORACLE_INIT_FIELD(Frame, obj_location),
-    TRACK_ORACLE_INIT_FIELD(Frame, bounding_box)
+  TRACK_ORACLE_FIELD(tracking, obj_location);
+  TRACK_ORACLE_FIELD(tracking, bounding_box);
+
+  visgui_base_track_type()
     {
+    Track.add_field(external_id);
+
+    Frame.add_field(bounding_box);
+    Frame.add_field(obj_location);
     }
 };
 
@@ -40,11 +41,11 @@ struct visgui_base_track_type :
 struct visgui_fn_track_type :
   public track_oracle::track_base<visgui_fn_track_type, visgui_base_track_type>
 {
-  track_oracle::track_field<unsigned>& frame_number;
+  TRACK_ORACLE_FIELD(tracking, frame_number);
 
-  visgui_fn_track_type() :
-    TRACK_ORACLE_INIT_FIELD(Frame, frame_number)
+  visgui_fn_track_type()
     {
+    Frame.add_field(frame_number);
     }
 };
 
@@ -52,11 +53,11 @@ struct visgui_fn_track_type :
 struct visgui_ts_track_type :
   public track_oracle::track_base<visgui_ts_track_type, visgui_base_track_type>
 {
-  track_oracle::track_field<unsigned long long>& timestamp_usecs;
+  TRACK_ORACLE_FIELD(tracking, timestamp_usecs);
 
-  visgui_ts_track_type() :
-    TRACK_ORACLE_INIT_FIELD(Frame, timestamp_usecs)
+  visgui_ts_track_type()
     {
+    Frame.add_field(timestamp_usecs);
     }
 };
 
@@ -64,13 +65,13 @@ struct visgui_ts_track_type :
 struct visgui_track_type :
   public track_oracle::track_base<visgui_track_type, visgui_base_track_type>
 {
-  track_oracle::track_field<unsigned long long>& timestamp_usecs;
-  track_oracle::track_field<unsigned>& frame_number;
+  TRACK_ORACLE_FIELD(tracking, timestamp_usecs);
+  TRACK_ORACLE_FIELD(tracking, frame_number);
 
-  visgui_track_type() :
-    TRACK_ORACLE_INIT_FIELD(Frame, timestamp_usecs),
-    TRACK_ORACLE_INIT_FIELD(Frame, frame_number)
+  visgui_track_type()
     {
+    Frame.add_field(timestamp_usecs);
+    Frame.add_field(frame_number);
     }
 };
 

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleTrackArchiveSource.cxx
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/vsTrackOracleTrackArchiveSource.cxx
@@ -34,6 +34,17 @@ namespace track_oracle
 }
 #endif
 
+namespace
+{
+
+//-----------------------------------------------------------------------------
+QString fieldName(const track_oracle::track_field_base& field)
+{
+  return qtString(field.get_field_name());
+}
+
+} // namespace <anonymous>
+
 //-----------------------------------------------------------------------------
 class vsTrackOracleTrackArchiveSourcePrivate : public vsArchiveSourcePrivate
 {
@@ -92,7 +103,7 @@ bool vsTrackOracleTrackArchiveSourcePrivate::processArchive(const QUrl& uri)
     // number
     // TODO Allow missing time value once core supports time mapping
     if (missingFields.count() > 1 ||
-        *missingFields.begin() != "frame_number")
+        *missingFields.begin() != fieldName(schema.frame_number))
       {
       qWarning() << "unable to load tracks from" << uri
                  << "due to missing fields" << missingFields;


### PR DESCRIPTION
Convert the data frameworks and vspSourceService track_oracle plugins over to using track_oracle data terms for setting up their schemas, at least for the track readers. (Many of the event fields do not have data terms, so for now the event reader is unchanged.)

Also, update the data frameworks reader to use the `track_uuid` field (which exists in both VidTK and KWIVER, and seems to be actively used) rather than the `unique_id` field (which exists only in VidTK and is specific to STANAG 4676, which is not supported by KWIVER at this time.)

In addition, modify the data frameworks track_oracle plugin to also read the world location GCS from tracks. This makes it possible to read tracks that use a different GCS, rather than the hard-coded default WGS'84 lat/lon.

Note that the latter change depends on https://github.com/Kitware/kwiver/pull/543.