### PR TITLE
Use fletch

### DIFF
--- a/CMake/coredeps.cmake
+++ b/CMake/coredeps.cmake
@@ -1,5 +1,11 @@
 list(APPEND CMAKE_MODULE_PATH ${visGUI_SOURCE_DIR}/CMake/Modules)
 
+find_package(fletch NO_MODULE)
+if (fletch_FOUND)
+  # Search for libraries in the fletch install root
+  list(APPEND CMAKE_PREFIX_PATH "${fletch_ROOT}")
+endif()
+
 # Boost is required.
 find_package(Boost REQUIRED
   COMPONENTS thread signals system filesystem date_time


### PR DESCRIPTION
Fletch is part of the [KWIVER](http://www.kwiver.org/) ecosystem, of which ViViA is also a part. The purpose of fletch is to provide external third-party dependencies required by KWIVER software. Previously, we have had an implicit dependency on fletch, in that some or all of ViViA's third-party dependencies would typically be provided by fletch, with the developer manually specifying their paths. Adding fletch as an optional dependency allows us to discover those dependencies which are provided by fletch without additional user intervention, which makes it easier to configure ViViA.