### PR TITLE
Implement TOC support in WAMI Viewer

### DIFF
--- a/Applications/VpView/vpFseIO.cxx
+++ b/Applications/VpView/vpFseIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -18,7 +18,6 @@ vpFseIO::vpFseIO() :
 //-----------------------------------------------------------------------------
 vpFseIO::~vpFseIO()
 {
-  delete this->TrackIO;
 }
 
 //-----------------------------------------------------------------------------
@@ -29,12 +28,12 @@ void vpFseIO::SetTrackModel(vtkVpTrackModel* trackModel,
                             vtkMatrix4x4* geoTransform,
                             vpFrameMap* frameMap)
 {
-  delete this->TrackIO;
-  vpFseTrackIO* io = new vpFseTrackIO(trackModel, storageMode, timeStampMode,
-                                      trackTypes, geoTransform, frameMap);
+  std::unique_ptr<vpFseTrackIO> io{
+    new vpFseTrackIO(trackModel, storageMode, timeStampMode,
+                     trackTypes, geoTransform, frameMap)};
   io->SetImageHeight(this->ImageHeight);
   io->SetTracksFileName(this->TracksFilename.c_str());
-  this->TrackIO = io;
+  this->TrackIO = std::move(io);
 }
 
 //-----------------------------------------------------------------------------
@@ -55,7 +54,7 @@ void vpFseIO::SetTracksFileName(const char* tracksFileName)
   this->TracksFilename = tracksFileName;
   if (this->TrackIO)
     {
-    static_cast<vpFseTrackIO*>(this->TrackIO)->SetTracksFileName(tracksFileName);
+    static_cast<vpFseTrackIO*>(this->TrackIO.get())->SetTracksFileName(tracksFileName);
     }
 }
 
@@ -65,7 +64,7 @@ void vpFseIO::SetImageHeight(unsigned int imageHeight)
   this->ImageHeight = imageHeight;
   if (this->TrackIO)
     {
-    static_cast<vpFseTrackIO*>(this->TrackIO)->SetImageHeight(imageHeight);
+    static_cast<vpFseTrackIO*>(this->TrackIO.get())->SetImageHeight(imageHeight);
     }
 }
 

--- a/Applications/VpView/vpModelIO.cxx
+++ b/Applications/VpView/vpModelIO.cxx
@@ -1,19 +1,17 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
 #include "vpModelIO.h"
 
-#include "vpFseTrackIO.h"
-
 #include <assert.h>
 
 //-----------------------------------------------------------------------------
-vpModelIO::vpModelIO() :
-  TrackIO(0), EventIO(0), ActivityIO(0), FseTrackIO(0)
-{}
+vpModelIO::vpModelIO()
+{
+}
 
 //-----------------------------------------------------------------------------
 void vpModelIO::SetTrackOverrideColor(const vgColor& color)

--- a/Applications/VpView/vpModelIO.h
+++ b/Applications/VpView/vpModelIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,14 +7,15 @@
 #ifndef __vpModelIO_h
 #define __vpModelIO_h
 
-#include "vpTrackIO.h"
-#include "vpEventIO.h"
 #include "vpActivityIO.h"
+#include "vpEventIO.h"
+#include "vpFseTrackIO.h"
+#include "vpTrackIO.h"
 
+#include <memory>
 #include <vector>
 
 class vpFrameMap;
-class vpFseTrackIO;
 
 class vpModelIO
 {
@@ -70,16 +71,16 @@ public:
 
   bool WriteFseTracks(const char* filename, bool writeSceneElements = true);
 
-  const vpTrackIO* GetTrackIO() const { return this->TrackIO; }
-  const vpEventIO* GetEventIO() const { return this->EventIO; }
-  const vpActivityIO* GetActivityIO() const { return this->ActivityIO; }
-  const vpFseTrackIO* GetFseTrackIO() const { return this->FseTrackIO; }
+  const vpTrackIO* GetTrackIO() const { return this->TrackIO.get(); }
+  const vpEventIO* GetEventIO() const { return this->EventIO.get(); }
+  const vpActivityIO* GetActivityIO() const { return this->ActivityIO.get(); }
+  const vpFseTrackIO* GetFseTrackIO() const { return this->FseTrackIO.get(); }
 
 protected:
-  vpTrackIO* TrackIO;
-  vpEventIO* EventIO;
-  vpActivityIO* ActivityIO;
-  vpFseTrackIO* FseTrackIO;
+  std::unique_ptr<vpTrackIO> TrackIO;
+  std::unique_ptr<vpEventIO> EventIO;
+  std::unique_ptr<vpActivityIO> ActivityIO;
+  std::unique_ptr<vpFseTrackIO> FseTrackIO;
 };
 
 #endif // __vpModelIO_h

--- a/Applications/VpView/vpObjectInfoPanel.ui
+++ b/Applications/VpView/vpObjectInfoPanel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>234</width>
-    <height>216</height>
+    <width>327</width>
+    <height>316</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -357,16 +357,9 @@
            </widget>
           </item>
           <item row="6" column="0">
-           <widget class="QLabel" name="trackPVOLabel">
+           <widget class="QLabel" name="trackClassifiersLabel">
             <property name="text">
-             <string>PVO:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QLabel" name="trackPVO">
-            <property name="text">
-             <string>P: 0.0, V: 0.0, O: 0.0</string>
+             <string>Classifiers:</string>
             </property>
            </widget>
           </item>
@@ -385,6 +378,38 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QTreeWidget" name="trackClassifiers">
+            <property name="alternatingRowColors">
+             <bool>true</bool>
+            </property>
+            <property name="rootIsDecorated">
+             <bool>false</bool>
+            </property>
+            <property name="uniformRowHeights">
+             <bool>true</bool>
+            </property>
+            <property name="sortingEnabled">
+             <bool>true</bool>
+            </property>
+            <property name="allColumnsShowFocus">
+             <bool>true</bool>
+            </property>
+            <property name="columnCount">
+             <number>2</number>
+            </property>
+            <column>
+             <property name="text">
+              <string>Type</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Score</string>
+             </property>
+            </column>
            </widget>
           </item>
          </layout>

--- a/Applications/VpView/vpTrackIO.cxx
+++ b/Applications/VpView/vpTrackIO.cxx
@@ -134,3 +134,20 @@ void vpTrackIO::AddTrack(vtkVgTrack* track)
   this->TrackModel->AddTrack(track);
   track->FastDelete();
 }
+
+//-----------------------------------------------------------------------------
+int vpTrackIO::GetTrackTypeIndex(const char* typeName)
+{
+  const auto index = this->TrackTypes->GetTypeIndex(typeName);
+
+  if (index >= 0)
+    {
+    return index;
+    }
+
+  vgTrackType type;
+  type.SetId(typeName);
+
+  this->TrackTypes->AddType(type);
+  return this->TrackTypes->GetTypeIndex(typeName);
+}

--- a/Applications/VpView/vpTrackIO.h
+++ b/Applications/VpView/vpTrackIO.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -77,6 +77,8 @@ public:
   virtual vtkIdType GetModelTrackId(unsigned int sourceId) const;
 
   static void GetDefaultTrackColor(int trackId, double (&color)[3]);
+
+  int GetTrackTypeIndex(const char* typeName);
 
 protected:
   virtual unsigned int GetImageHeight() const = 0;

--- a/Applications/VpView/vpVidtkFileIO.cxx
+++ b/Applications/VpView/vpVidtkFileIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -19,7 +19,6 @@ vpVidtkFileIO::vpVidtkFileIO() :
 //-----------------------------------------------------------------------------
 vpVidtkFileIO::~vpVidtkFileIO()
 {
-  delete this->FseTrackIO;
 }
 
 //-----------------------------------------------------------------------------
@@ -30,17 +29,16 @@ void vpVidtkFileIO::SetTrackModel(vtkVpTrackModel* trackModel,
                                   vtkMatrix4x4* geoTransform,
                                   vpFrameMap* frameMap)
 {
-  delete this->TrackIO;
   this->TrackMap.clear();
-  this->TrackIO = new vpVidtkFileTrackIO(
-                    this->Reader, this->TrackMap,
-                    this->SourceTrackIdToModelIdMap, trackModel,
-                    storageMode, timeStampMode, trackTypes,
-                    geoTransform, frameMap);
+  this->TrackIO.reset(
+    new vpVidtkFileTrackIO(this->Reader, this->TrackMap,
+                           this->SourceTrackIdToModelIdMap, trackModel,
+                           storageMode, timeStampMode, trackTypes,
+                           geoTransform, frameMap));
 
-  delete this->FseTrackIO;
-  this->FseTrackIO = new vpFseTrackIO(trackModel, storageMode, timeStampMode,
-                                      trackTypes, geoTransform, frameMap);
+  this->FseTrackIO.reset(
+    new vpFseTrackIO(trackModel, storageMode, timeStampMode,
+                     trackTypes, geoTransform, frameMap));
   this->FseTrackIO->SetTracksFileName(this->FseTracksFileName.c_str());
   this->FseTrackIO->SetImageHeight(this->ImageHeight);
 }
@@ -49,13 +47,12 @@ void vpVidtkFileIO::SetTrackModel(vtkVpTrackModel* trackModel,
 void vpVidtkFileIO::SetEventModel(vtkVgEventModel* eventModel,
                                   vtkVgEventTypeRegistry* eventTypes)
 {
-  delete this->EventIO;
   this->EventMap.clear();
-  this->EventIO = new vpVidtkFileEventIO(
-                    this->Reader,
-                    this->EventMap, this->SourceEventIdToModelIdMap,
-                    this->TrackMap, this->SourceTrackIdToModelIdMap,
-                    eventModel, eventTypes);
+  this->EventIO.reset(
+    new vpVidtkFileEventIO(this->Reader,
+                           this->EventMap, this->SourceEventIdToModelIdMap,
+                           this->TrackMap, this->SourceTrackIdToModelIdMap,
+                           eventModel, eventTypes));
 }
 
 //-----------------------------------------------------------------------------

--- a/Applications/VpView/vpVidtkIO.cxx
+++ b/Applications/VpView/vpVidtkIO.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -14,9 +14,6 @@
 //-----------------------------------------------------------------------------
 vpVidtkIO::~vpVidtkIO()
 {
-  delete this->ActivityIO;
-  delete this->EventIO;
-  delete this->TrackIO;
 }
 
 //-----------------------------------------------------------------------------
@@ -27,34 +24,32 @@ void vpVidtkIO::SetTrackModel(vtkVpTrackModel* trackModel,
                               vtkMatrix4x4* geoTransform,
                               vpFrameMap* frameMap)
 {
-  delete this->TrackIO;
   this->TrackMap.clear();
-  this->TrackIO = new vpVidtkTrackIO(this->GetReader(), this->TrackMap,
-                                     this->SourceTrackIdToModelIdMap,
-                                     trackModel, storageMode, timeStampMode,
-                                     trackTypes, geoTransform, frameMap);
+  this->TrackIO.reset(
+    new vpVidtkTrackIO(this->GetReader(), this->TrackMap,
+                       this->SourceTrackIdToModelIdMap,
+                       trackModel, storageMode, timeStampMode,
+                       trackTypes, geoTransform, frameMap));
 }
 
 //-----------------------------------------------------------------------------
 void vpVidtkIO::SetEventModel(vtkVgEventModel* eventModel,
                               vtkVgEventTypeRegistry* eventTypes)
 {
-  delete this->EventIO;
   this->EventMap.clear();
-  this->EventIO = new vpVidtkEventIO(this->GetReader(), this->EventMap,
-                                     this->SourceEventIdToModelIdMap,
-                                     this->TrackMap,
-                                     this->SourceTrackIdToModelIdMap,
-                                     eventModel, eventTypes);
+  this->EventIO.reset(
+    new vpVidtkEventIO(this->GetReader(),
+                       this->EventMap, this->SourceEventIdToModelIdMap,
+                       this->TrackMap, this->SourceTrackIdToModelIdMap,
+                       eventModel, eventTypes));
 }
 
 //-----------------------------------------------------------------------------
 void vpVidtkIO::SetActivityModel(vtkVgActivityManager* activityManager,
                                  vpActivityConfig* activityConfig)
 {
-  delete this->ActivityIO;
-  this->ActivityIO = new vpVidtkActivityIO(this->GetReader(), activityManager,
-                                           activityConfig);
+  this->ActivityIO.reset(
+    new vpVidtkActivityIO(this->GetReader(), activityManager, activityConfig));
 }
 
 //-----------------------------------------------------------------------------
@@ -75,6 +70,6 @@ void vpVidtkIO::UpdateTracks(const std::vector<vidtk::track_sptr>& tracks,
                              unsigned int updateEndFrame)
 {
   assert(this->TrackIO);
-  static_cast<vpVidtkTrackIO*>(this->TrackIO)->UpdateTracks(
+  static_cast<vpVidtkTrackIO*>(this->TrackIO.data())->UpdateTracks(
     tracks, updateStartFrame, updateEndFrame);
 }

--- a/Applications/VpView/vpVidtkTrackIO.cxx
+++ b/Applications/VpView/vpVidtkTrackIO.cxx
@@ -682,9 +682,15 @@ void vpVidtkTrackIO::ReadTrack(
   vidtk::pvo_probability pvo;
   if (vidtkTrack->get_pvo(pvo))
     {
-    track->SetPVO(pvo.get_probability_person(),
-                  pvo.get_probability_vehicle(),
-                  pvo.get_probability_other());
+    const auto personTypeIndex  = this->GetTrackTypeIndex("Person");
+    const auto vehicleTypeIndex = this->GetTrackTypeIndex("Vehicle");
+    const auto otherTypeIndex   = this->GetTrackTypeIndex("Other");
+
+    std::map<int, double> toc;
+    toc.emplace(personTypeIndex,  pvo.get_probability_person());
+    toc.emplace(vehicleTypeIndex, pvo.get_probability_vehicle());
+    toc.emplace(otherTypeIndex,   pvo.get_probability_other());
+    track->SetTOC(toc);
     }
 
   const std::vector<vidtk::track_state_sptr>& trackHistory =

--- a/Applications/VpView/vpView.cxx
+++ b/Applications/VpView/vpView.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -44,6 +44,7 @@
 #include <vtkVgEventModel.h>
 #include <vtkVgTemporalFilters.h>
 #include <vtkVgTrackRepresentationBase.h>
+#include <vtkVgTrackTypeRegistry.h>
 
 #include <QVTKWidget.h>
 #include <vtkRenderer.h>
@@ -860,7 +861,7 @@ void vpView::onDataLoaded()
 
   this->Internal->UI.actionViewTracks->setEnabled(true);
   this->Internal->UI.actionViewTrackHeads->setEnabled(true);
-  this->Internal->UI.pvoFilter->setEnabled(true);
+  this->Internal->UI.tocFilter->setEnabled(true);
 
   this->Internal->UI.actionViewEvents->setEnabled(true);
   this->Internal->UI.normalcyFilter->setEnabled(true);
@@ -1694,7 +1695,10 @@ void vpView::setupDock()
 void vpView::postLoadConfig()
 {
   this->Core->setupTrackAttributeColors();
-  this->Core->setupTrackFilters(this->Internal->UI.pvoFilter);
+  this->Core->setupTrackFilters(this->Internal->UI.tocFilter);
+
+  connect(this->Core, SIGNAL(trackTypesModified()),
+          this, SLOT(updateTrackFilters()));
 }
 
 //-----------------------------------------------------------------------------
@@ -1754,6 +1758,40 @@ void vpView::postDataLoaded()
 void vpView::exitApp()
 {
   this->close();
+}
+
+//-----------------------------------------------------------------------------
+void vpView::updateTrackFilters()
+{
+  auto oldTypes = this->Internal->UI.tocFilter->keys().toSet();
+  auto* const ttr = this->Core->getTrackTypeRegistry();
+
+  const int k = ttr->GetNumberOfTypes();
+  for (int i = 0; i < k; ++i)
+    {
+    const auto& tt = ttr->GetEntityType(i);
+    const auto& typeName = QString::fromLocal8Bit(tt.GetName());
+
+    if (typeName.isEmpty())
+      {
+      // Handle "deleted" types
+      if (oldTypes.contains(i))
+        {
+        this->Internal->UI.tocFilter->removeItem(i);
+        }
+      }
+    else
+      {
+      if (oldTypes.contains(i))
+        {
+        this->Internal->UI.tocFilter->setText(i, typeName);
+        }
+      else
+        {
+        this->Core->addTrackFilter(this->Internal->UI.tocFilter, i, typeName);
+        }
+      }
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/Applications/VpView/vpView.h
+++ b/Applications/VpView/vpView.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -193,6 +193,8 @@ public slots:
   void pickTimeInterval();
 
   void executeExternalProcess();
+
+  void updateTrackFilters();
 
 protected:
   virtual void closeEvent(QCloseEvent*);  // reimplemented from QWidget

--- a/Applications/VpView/vpView.ui
+++ b/Applications/VpView/vpView.ui
@@ -369,7 +369,7 @@
        <number>4</number>
       </property>
       <item>
-       <widget class="QGroupBox" name="pvoGroupBox">
+       <widget class="QGroupBox" name="tocGroupBox">
         <property name="title">
          <string>Tracks</string>
         </property>
@@ -387,7 +387,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="vgMixerWidget" name="pvoFilter" native="true">
+          <widget class="vgMixerWidget" name="tocFilter" native="true">
            <property name="enabled">
             <bool>false</bool>
            </property>

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -128,7 +128,7 @@
 #include <vtkVgRendererUtils.h>
 #include <vtkVgTemporalFilters.h>
 #include <vtkVgTrack.h>
-#include <vtkVgTrackFilter.h>
+#include <vtkVgTrackPVOFilter.h>
 #include <vtkVgTrackHeadRepresentation.h>
 #include <vtkVgTrackRepresentation.h>
 #include <vtkVgTrackTypeRegistry.h>
@@ -1656,7 +1656,7 @@ void vpViewCore::initializeScene()
   this->IconSize = 16;
   this->IconOffsetX = this->IconOffsetY = 5;
 
-  this->TrackFilter = vtkSmartPointer<vtkVgTrackFilter>::New();
+  this->TrackFilter = vtkSmartPointer<vtkVgTrackPVOFilter>::New();
   this->TrackFilter->SetShowType(vtkVgTrack::Person, true);
   this->TrackFilter->SetShowType(vtkVgTrack::Vehicle, true);
   this->TrackFilter->SetShowType(vtkVgTrack::Other, true);

--- a/Applications/VpView/vpViewCore.h
+++ b/Applications/VpView/vpViewCore.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2017 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -140,6 +140,9 @@ public:
   inline void setTrackOffset(int* trackOffset);
 
   void setOverviewDisplay(vpProject* project);
+
+  void addTrackFilter(vgMixerWidget* filterWidget, int typeId,
+                      const QString& typeName);
 
   // Set/Get functions.
   inline int    getNumberOfFrames();
@@ -298,6 +301,16 @@ public:
   inline vtkVgEventTypeRegistry* getEventTypeRegistry()
     {
     return this->EventTypeRegistry;
+    }
+
+  inline const vtkVgTrackTypeRegistry* getTrackTypeRegistry() const
+    {
+    return this->TrackTypeRegistry;
+    }
+
+  inline vtkVgTrackTypeRegistry* getTrackTypeRegistry()
+    {
+    return this->TrackTypeRegistry;
     }
 
   void setTrackTrailLength(const vtkVgTimeStamp& duration);
@@ -600,6 +613,8 @@ signals:
   void iconsLoaded();
   void overviewLoaded();
   void followTrackChange(int trackId);
+
+  void trackTypesModified();
 
   void displayZoom();
   void frameChanged();

--- a/Libraries/VspUserInterface/vsScene.cxx
+++ b/Libraries/VspUserInterface/vsScene.cxx
@@ -42,7 +42,7 @@
 #include <vtkVgEventModel.h>
 #include <vtkVgEventRegionRepresentation.h>
 #include <vtkVgEventRepresentation.h>
-#include <vtkVgTrackFilter.h>
+#include <vtkVgTrackPVOFilter.h>
 #include <vtkVgTrackHeadRepresentation.h>
 #include <vtkVgTrackLabelRepresentation.h>
 #include <vtkVgTrackModel.h>

--- a/Libraries/VspUserInterface/vsScenePrivate.cxx
+++ b/Libraries/VspUserInterface/vsScenePrivate.cxx
@@ -33,7 +33,7 @@
 #include <vtkVgEventRegionRepresentation.h>
 #include <vtkVgEventRepresentation.h>
 #include <vtkVgSpaceConversion.h>
-#include <vtkVgTrackFilter.h>
+#include <vtkVgTrackPVOFilter.h>
 #include <vtkVgTrackHeadRepresentation.h>
 #include <vtkVgTrackLabelRepresentation.h>
 #include <vtkVgTrackModel.h>

--- a/Libraries/VspUserInterface/vsScenePrivate.h
+++ b/Libraries/VspUserInterface/vsScenePrivate.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2015 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -46,7 +46,7 @@ class vtkVgContourOperatorManager;
 class vtkVgRepresentationBase;
 class vtkVgTrack;
 class vtkVgTrackInfo;
-class vtkVgTrackFilter;
+class vtkVgTrackPVOFilter;
 class vtkVgTrackModel;
 class vtkVgTrackRepresentation;
 class vtkVgTrackHeadRepresentation;
@@ -224,7 +224,7 @@ public:
 
   vtkVgInstance<vtkVgContourOperatorManager> ContourOperatorManager;
 
-  vtkVgInstance<vtkVgTrackFilter> TrackFilter;
+  vtkVgInstance<vtkVgTrackPVOFilter> TrackFilter;
   vtkVgInstance<vtkVgEventFilter> EventFilter;
 
   Graph NormalGraph;

--- a/Libraries/VtkVgCore/vtkVgTrack.cxx
+++ b/Libraries/VtkVgCore/vtkVgTrack.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -21,6 +21,7 @@
 
 #include <limits>
 #include <map>
+#include <numeric>
 
 vtkStandardNewMacro(vtkVgTrack);
 vtkCxxSetObjectMacro(vtkVgTrack, Points, vtkPoints);
@@ -310,6 +311,8 @@ void vtkVgTrack::CopyData(vtkVgTrack* other)
   this->PVO[0] = other->PVO[0];
   this->PVO[1] = other->PVO[1];
   this->PVO[2] = other->PVO[2];
+
+  this->TOC = other->TOC;
 }
 
 //-----------------------------------------------------------------------------
@@ -1257,6 +1260,69 @@ int vtkVgTrack::GetBestPVOClassifier()
     }
 
   return vtkVgTrack::Other;
+}
+
+//-----------------------------------------------------------------------------
+void vtkVgTrack::SetTOC(const std::map<int, double>& toc)
+{
+  // Get cumulative confidence
+  static const auto extractConfidence =
+    [](double a, const std::pair<int, double>& p){ return a + p.second; };
+  const auto sum =
+    std::accumulate(toc.begin(), toc.end(), 0.0, extractConfidence);
+
+  // If cumulative confidence is not 1.0 (within some slop), normalize the
+  // input TOC and apply that instead
+  if (fabs(sum - 1.0)> 1e-8)
+    {
+    const auto invSum = 1.0 / sum;
+    std::map<int, double> normalizedToc;
+
+    for (const auto& c : toc)
+      {
+      normalizedToc.emplace(c.first, c.second * invSum);
+      }
+
+    this->SetTOC(normalizedToc);
+    return;
+    }
+
+  if (this->TOC == toc)
+    {
+    return;
+    }
+
+  this->TOC = toc;
+  this->Modified();
+}
+
+//-----------------------------------------------------------------------------
+std::map<int, double> vtkVgTrack::GetTOC() const
+{
+  return this->TOC;
+}
+
+//-----------------------------------------------------------------------------
+std::pair<int, double> vtkVgTrack::GetBestTOCClassifier()
+{
+  auto bestClassifier = std::pair<int, double>{-1, 0.0};
+
+  for (auto c : this->TOC)
+    {
+    if (c.second > bestClassifier.second)
+      {
+      bestClassifier = c;
+      }
+    }
+
+  return bestClassifier;
+}
+
+//-----------------------------------------------------------------------------
+double vtkVgTrack::GetTOCScore(int type)
+{
+  auto i = this->TOC.find(type);
+  return (i == this->TOC.end() ? -1.0 : i->second);
 }
 
 //-----------------------------------------------------------------------------

--- a/Libraries/VtkVgCore/vtkVgTrack.h
+++ b/Libraries/VtkVgCore/vtkVgTrack.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -14,6 +14,7 @@
 #include "vtkVgSetGet.h"
 #include "vtkVgTimeStamp.h"
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -257,13 +258,21 @@ public:
   vtkSetMacro(Type, int);
   vtkGetMacro(Type, int);
 
-  // Description:
-  // Set/Get the PVO classification for this track.  These must sum to 1;
-  // to guarantee summing to 1, we normalize on input.
+  // DEPRECATED (TODO: remove this)
   void SetPVO(double person, double vehicle, double other);
   void SetPVO(double pvo[3]);
   vtkGetVector3Macro(PVO, double);
 
+  // Description:
+  // Set/Get the object classification for this track.  These must sum to 1;
+  // to guarantee summing to 1, we normalize on input.
+  void SetTOC(const std::map<int, double>& toc);
+  std::map<int, double> GetTOC() const;
+
+  // TODO
+  // constexpr static int Unclassified = 0;
+
+  // DEPRECATED (TODO: remove this)
   enum enumTrackPVOType
     {
     Person = 0,
@@ -272,7 +281,11 @@ public:
     Unclassified
     };
 
+  // DEPRECATED (TODO: remove this)
   int GetBestPVOClassifier();
+
+  std::pair<int, double> GetBestTOCClassifier();
+  double GetTOCScore(int type);
 
   // Description:
   // Support for per-track colors.
@@ -393,6 +406,7 @@ private:
 
   double Normalcy;
   double PVO[3];
+  std::map<int, double> TOC;
 
   double Color[3];
 

--- a/Libraries/VtkVgModelView/CMakeLists.txt
+++ b/Libraries/VtkVgModelView/CMakeLists.txt
@@ -29,6 +29,7 @@ set(vtkVgModelViewSrcs
   vtkVgTrackLabelRepresentation.cxx
   vtkVgTrackModel.cxx
   vtkVgTrackModelCollection.cxx
+  vtkVgTrackPVOFilter.cxx
   vtkVgTrackRepresentation.cxx
   vtkVgTrackRepresentationBase.cxx
   vtkVgTripWireManager.cxx
@@ -67,6 +68,7 @@ set(vtkVgModelViewInstallHeaders
   vtkVgTrackLabelRepresentation.h
   vtkVgTrackModelCollection.h
   vtkVgTrackModel.h
+  vtkVgTrackPVOFilter.h
   vtkVgTrackRepresentationBase.h
   vtkVgTrackRepresentation.h
   vtkVgTripWireManager.h

--- a/Libraries/VtkVgModelView/vtkVgTrackFilter.cxx
+++ b/Libraries/VtkVgModelView/vtkVgTrackFilter.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -15,13 +15,6 @@ vtkStandardNewMacro(vtkVgTrackFilter);
 //-----------------------------------------------------------------------------
 vtkVgTrackFilter::vtkVgTrackFilter()
 {
-  this->FilterShow[0] = this->FilterShow[1] = this->FilterShow[2] = false;
-  this->FilterMinProbability[0] = 1.0;
-  this->FilterMinProbability[1] = 1.0;
-  this->FilterMinProbability[2] = 1.0;
-  this->FilterMaxProbability[0] = 0.0;
-  this->FilterMaxProbability[1] = 0.0;
-  this->FilterMaxProbability[2] = 0.0;
 }
 
 //-----------------------------------------------------------------------------
@@ -32,89 +25,86 @@ vtkVgTrackFilter::~vtkVgTrackFilter()
 //-----------------------------------------------------------------------------
 void vtkVgTrackFilter::SetShowType(int trackType, bool state)
 {
-  if (trackType < vtkVgTrack::Person || trackType > vtkVgTrack::Other)
+  const auto i = this->Filters.find(trackType);
+  if (i == this->Filters.end())
     {
-    vtkErrorMacro("Invalid track type: " << trackType);
-    return;
+    this->Filters.emplace(trackType, FilterSettings{state, 1.0, 0.0});
+    this->Modified();
     }
-
-  if (this->FilterShow[trackType] == state)
+  else if (i->second.Show != state)
     {
-    return;
+    i->second.Show = state;
+    this->Modified();
     }
-
-  this->FilterShow[trackType] = state;
-  this->Modified();
 }
 
 //-----------------------------------------------------------------------------
 bool vtkVgTrackFilter::GetShowType(int trackType)
 {
-  if (trackType < vtkVgTrack::Person || trackType > vtkVgTrack::Other)
+  const auto i = this->Filters.find(trackType);
+  if (i == this->Filters.end())
     {
     vtkErrorMacro("Invalid track type: " << trackType);
     return false;
     }
-  return this->FilterShow[trackType];
+  return i->second.Show;
 }
 
 //-----------------------------------------------------------------------------
 void vtkVgTrackFilter::SetMinProbability(int trackType, double threshold)
 {
-  if (trackType < vtkVgTrack::Person || trackType > vtkVgTrack::Other)
+  const auto i = this->Filters.find(trackType);
+  if (i == this->Filters.end())
     {
-    vtkErrorMacro("Invalid track type: " << trackType);
-    return;
+    this->Filters.emplace(trackType, FilterSettings{false, threshold, 0.0});
+    this->Modified();
     }
-
-  if (this->FilterMinProbability[trackType] == threshold)
+  else if (i->second.MinProbability != threshold)
     {
-    return;
+    i->second.MinProbability = threshold;
+    this->Modified();
     }
-
-  this->FilterMinProbability[trackType] = threshold;
-  this->Modified();
 }
 
 
 //-----------------------------------------------------------------------------
 double vtkVgTrackFilter::GetMinProbability(int trackType)
 {
-  if (trackType < vtkVgTrack::Person || trackType > vtkVgTrack::Other)
+  const auto i = this->Filters.find(trackType);
+  if (i == this->Filters.end())
     {
     vtkErrorMacro("Invalid track type: " << trackType);
     return 1.0;
     }
-  return this->FilterMinProbability[trackType];
+  return i->second.MinProbability;
 }
 
 //-----------------------------------------------------------------------------
 void vtkVgTrackFilter::SetMaxProbability(int trackType, double threshold)
 {
-  if (trackType < vtkVgTrack::Person || trackType > vtkVgTrack::Other)
+  const auto i = this->Filters.find(trackType);
+  if (i == this->Filters.end())
     {
-    vtkErrorMacro("Invalid track type: " << trackType);
-    return;
+    this->Filters.emplace(trackType, FilterSettings{false, 1.0, threshold});
+    this->Modified();
     }
-
-  if (this->FilterMaxProbability[trackType] == threshold)
+  else if (i->second.MaxProbability != threshold)
     {
-    return;
+    i->second.MaxProbability = threshold;
+    this->Modified();
     }
-
-  this->FilterMaxProbability[trackType] = threshold;
-  this->Modified();
 }
 
 //-----------------------------------------------------------------------------
 double vtkVgTrackFilter::GetMaxProbability(int trackType)
 {
-  if (trackType < vtkVgTrack::Person || trackType > vtkVgTrack::Other)
+  const auto i = this->Filters.find(trackType);
+  if (i == this->Filters.end())
     {
     vtkErrorMacro("Invalid track type: " << trackType);
-    return 1.0;
+    return 0.0;
     }
-  return this->FilterMaxProbability[trackType];
+  return i->second.MaxProbability;
 }
 
 //-----------------------------------------------------------------------------
@@ -123,35 +113,40 @@ int vtkVgTrackFilter::GetBestClassifier(vtkVgTrack* track)
   int bestType = -1;
   double bestScore = -1.0;
 
-  double pvo[3];
-  track->GetPVO(pvo);
+  const auto& toc = track->GetTOC();
 
-  // if unclassified, doesn't matter what he filter setting are
-  if (pvo[0] == 0 && pvo[1] == 0 && pvo[2] == 0)
+  // If unclassified, doesn't matter what the filter setting are
+  if (!toc.size())
     {
-    return vtkVgTrack::Unclassified;
+    return std::numeric_limits<int>::max();
     }
 
-  int filterType;
-  for (filterType = vtkVgTrack::Person; filterType <= vtkVgTrack::Other; filterType++)
+  // Iterate over all filters
+  for (const auto& f : this->Filters)
     {
-    if (!this->FilterShow[filterType])
+    // Is this type shown?
+    if (!f.second.Show)
       {
       continue;
       }
-    if (pvo[filterType] < this->FilterMinProbability[filterType])
+
+    // Does the track have a classification for this type?
+    const auto i = toc.find(f.first);
+    if (i == toc.end())
       {
       continue;
       }
-    double maxProbability = this->FilterMaxProbability[filterType];
-    if (pvo[filterType] > maxProbability)
+
+    // Is the track's classification score for this type within the filter
+    // thresholds?
+    if (i->second >= f.second.MinProbability &&
+        i->second <= f.second.MaxProbability)
       {
-      continue;
-      }
-    if (pvo[filterType] > bestScore)
-      {
-      bestScore = pvo[filterType];
-      bestType = filterType;
+      if (i->second > bestScore)
+        {
+        bestScore = i->second;
+        bestType = f.first;
+        }
       }
     }
 

--- a/Libraries/VtkVgModelView/vtkVgTrackFilter.h
+++ b/Libraries/VtkVgModelView/vtkVgTrackFilter.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,9 +7,11 @@
 #ifndef __vtkVgTrackFilter_h
 #define __vtkVgTrackFilter_h
 
-#include "vtkObject.h"
-
 #include <vgExport.h>
+
+#include <vtkObject.h>
+
+#include <map>
 
 class vtkVgTrack;
 
@@ -38,20 +40,26 @@ public:
   double GetMaxProbability(int trackType);
 
   // Description:
-  // Get the highest scoring PVO classifier for a track given the current
+  // Get the highest scoring classifier for a track given the current
   // filter settings. Returns -1 if no classifiers pass the filter.
-  int GetBestClassifier(vtkVgTrack* track);
+  virtual int GetBestClassifier(vtkVgTrack* track);
 
-private:
-  vtkVgTrackFilter(const vtkVgTrackFilter&); // Not implemented.
-  void operator=(const vtkVgTrackFilter&);   // Not implemented.
-
+protected:
   vtkVgTrackFilter();
   ~vtkVgTrackFilter();
 
-  bool   FilterShow[3];
-  double FilterMinProbability[3];
-  double FilterMaxProbability[3];
+  struct FilterSettings
+  {
+    bool Show;
+    double MinProbability;
+    double MaxProbability;
+  };
+
+  std::map<int, FilterSettings> Filters;
+
+private:
+  vtkVgTrackFilter(const vtkVgTrackFilter&) = delete;
+  void operator=(const vtkVgTrackFilter&) = delete;
 };
 
 #endif // __vtkVgTrackFilter_h

--- a/Libraries/VtkVgModelView/vtkVgTrackPVOFilter.cxx
+++ b/Libraries/VtkVgModelView/vtkVgTrackPVOFilter.cxx
@@ -1,0 +1,70 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "vtkVgTrackPVOFilter.h"
+
+#include "vtkVgTrack.h"
+
+#include <vtkObjectFactory.h>
+
+vtkStandardNewMacro(vtkVgTrackPVOFilter);
+
+//-----------------------------------------------------------------------------
+vtkVgTrackPVOFilter::vtkVgTrackPVOFilter()
+{
+}
+
+//-----------------------------------------------------------------------------
+vtkVgTrackPVOFilter::~vtkVgTrackPVOFilter()
+{
+}
+
+//-----------------------------------------------------------------------------
+int vtkVgTrackPVOFilter::GetBestClassifier(vtkVgTrack* track)
+{
+  int bestType = -1;
+  double bestScore = -1.0;
+
+  double pvo[3];
+  track->GetPVO(pvo);
+
+  // if unclassified, doesn't matter what he filter setting are
+  if (pvo[0] == 0 && pvo[1] == 0 && pvo[2] == 0)
+    {
+    return vtkVgTrack::Unclassified;
+    }
+
+  int filterType;
+  for (filterType = vtkVgTrack::Person; filterType <= vtkVgTrack::Other; filterType++)
+    {
+    if (!this->GetShowType(filterType))
+      {
+      continue;
+      }
+    if (pvo[filterType] < this->GetMinProbability(filterType))
+      {
+      continue;
+      }
+    double maxProbability = this->GetMaxProbability(filterType);
+    if (pvo[filterType] > maxProbability)
+      {
+      continue;
+      }
+    if (pvo[filterType] > bestScore)
+      {
+      bestScore = pvo[filterType];
+      bestType = filterType;
+      }
+    }
+
+  return bestType;
+}
+
+//-----------------------------------------------------------------------------
+void vtkVgTrackPVOFilter::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}

--- a/Libraries/VtkVgModelView/vtkVgTrackPVOFilter.h
+++ b/Libraries/VtkVgModelView/vtkVgTrackPVOFilter.h
@@ -1,0 +1,36 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __vtkVgTrackPVOFilter_h
+#define __vtkVgTrackPVOFilter_h
+
+#include "vtkVgTrackFilter.h"
+
+class vtkVgTrack;
+
+// DEPRECATED
+class VTKVG_MODELVIEW_EXPORT vtkVgTrackPVOFilter : public vtkVgTrackFilter
+{
+public:
+  vtkTypeMacro(vtkVgTrackPVOFilter, vtkVgTrackFilter);
+  virtual void PrintSelf(ostream& os, vtkIndent indent);
+
+  static vtkVgTrackPVOFilter* New();
+
+  // Description:
+  // Get the highest scoring PVO classifier for a track given the current
+  // filter settings. Returns -1 if no classifiers pass the filter.
+  virtual int GetBestClassifier(vtkVgTrack* track) override;
+
+private:
+  vtkVgTrackPVOFilter(const vtkVgTrackPVOFilter&) = delete;
+  void operator=(const vtkVgTrackPVOFilter&) = delete;
+
+  vtkVgTrackPVOFilter();
+  ~vtkVgTrackPVOFilter();
+};
+
+#endif // __vtkVgTrackFilter_h


### PR DESCRIPTION
Modify WAMI Viewer to support the use of TOC's (Track Object Classifiers, which support dynamic classifications) rather than PVO's (static classifiers that support only Person, Vehicle, Other).