### PR TITLE
 Create WAMI Viewer project editor

### DIFF
--- a/Applications/VpView/CMakeLists.txt
+++ b/Applications/VpView/CMakeLists.txt
@@ -126,6 +126,7 @@ set(vpViewSources
   vpObjectSelectionPanel.cxx
   vpPrimitiveConfig.cxx
   vpProject.cxx
+  vpProjectEditor.cxx
   vpProjectList.cxx
   vpProjectParser.cxx
   vpQtSceneUtils.cxx
@@ -159,6 +160,7 @@ set(vpViewUI
   vpMergeTracksDialog.ui
   vpObjectInfoPanel.ui
   vpObjectSelectionPanel.ui
+  vpProjectEditor.ui
   vpQtViewer3dDialog.ui
   vpQtViewer3dWidget.ui
   vpSelectTimeIntervalDialog.ui
@@ -184,6 +186,7 @@ set(vpViewHeaders
   vpMergeTracksDialog.h
   vpObjectInfoPanel.h
   vpObjectSelectionPanel.h
+  vpProjectEditor.h
   vpProjectList.h
   vpQtViewer3d.h
   vpQtViewer3dDialog.h

--- a/Applications/VpView/vpProjectEditor.cxx
+++ b/Applications/VpView/vpProjectEditor.cxx
@@ -143,6 +143,7 @@ void vpProjectEditor::saveProject(const QString& path)
 {
   QTE_D();
   d->ProjectPath = path;
+  d->UI.saveInfo->setText(QString{"Project will be saved to %1."}.arg(path));
 }
 
 //-----------------------------------------------------------------------------

--- a/Applications/VpView/vpProjectEditor.cxx
+++ b/Applications/VpView/vpProjectEditor.cxx
@@ -72,6 +72,13 @@ vpProjectEditor::~vpProjectEditor()
 }
 
 //-----------------------------------------------------------------------------
+void vpProjectEditor::setDataset(const QString& path)
+{
+  QTE_D();
+  d->UI.dataset->setText(path);
+}
+
+//-----------------------------------------------------------------------------
 QString vpProjectEditor::projectPath() const
 {
   QTE_D();

--- a/Applications/VpView/vpProjectEditor.cxx
+++ b/Applications/VpView/vpProjectEditor.cxx
@@ -1,0 +1,175 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "vpProjectEditor.h"
+#include "ui_vpProjectEditor.h"
+
+#include "vpProject.h"
+
+#include <vgFileDialog.h>
+
+#include <qtConfirmationDialog.h>
+
+#include <QDir>
+#include <QMenu>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSettings>
+#include <QTemporaryFile>
+
+//-----------------------------------------------------------------------------
+class vpProjectEditorPrivate
+{
+public:
+  Ui_vpProjectEditor UI;
+
+  QString ProjectPath;
+  QScopedPointer<QTemporaryFile> TemporaryProject;
+};
+
+QTE_IMPLEMENT_D_FUNC(vpProjectEditor)
+
+//-----------------------------------------------------------------------------
+vpProjectEditor::vpProjectEditor(QWidget* parent, Qt::WindowFlags flags) :
+  QDialog{parent, flags}, d_ptr{new vpProjectEditorPrivate}
+{
+  QTE_D();
+
+  d->UI.setupUi(this);
+
+  auto* const okayButton = d->UI.buttons->button(QDialogButtonBox::Ok);
+  auto* const saveButton = d->UI.buttons->button(QDialogButtonBox::Save);
+
+  // Remove and re-add button; this breaks the button's association as a
+  // "standard button" and prevents the QDialogButtonBox from resetting the
+  // button's text
+  d->UI.buttons->removeButton(saveButton);
+  saveButton->setText("&Save As...");
+  d->UI.buttons->addButton(saveButton, QDialogButtonBox::AcceptRole);
+
+  connect(okayButton, SIGNAL(clicked()), this, SLOT(acceptProject()));
+  connect(saveButton, SIGNAL(clicked()), this, SLOT(saveProject()));
+
+  auto* const pickDatasetMenu = new QMenu{this};
+  pickDatasetMenu->addAction(d->UI.actionDatasetPickFile);
+  pickDatasetMenu->addAction(d->UI.actionDatasetPickDirectory);
+  d->UI.pickDataset->setMenu(pickDatasetMenu);
+
+  connect(d->UI.actionDatasetPickFile, SIGNAL(triggered()),
+          this, SLOT(browseForDatasetFile()));
+  connect(d->UI.actionDatasetPickDirectory, SIGNAL(triggered()),
+          this, SLOT(browseForDatasetDirectory()));
+  connect(d->UI.pickTracks, SIGNAL(clicked()),
+          this, SLOT(browseForTracksFile()));
+}
+
+//-----------------------------------------------------------------------------
+vpProjectEditor::~vpProjectEditor()
+{
+}
+
+//-----------------------------------------------------------------------------
+QString vpProjectEditor::projectPath() const
+{
+  QTE_D();
+  return d->ProjectPath;
+}
+
+//-----------------------------------------------------------------------------
+void vpProjectEditor::acceptProject()
+{
+  QTE_D();
+
+  // Check if project has been saved
+  if (d->ProjectPath.isEmpty())
+  {
+    if (!qtConfirmationDialog::getConfirmation(
+      this, "acceptTemporaryProject",
+      "Your project has not been saved. If you continue, "
+      "your project will be lost when you exit the application.",
+      "Are you sure?", "&Continue"))
+    {
+      return;
+    }
+
+    d->TemporaryProject.reset(new QTemporaryFile);
+    if (!d->TemporaryProject->open())
+    {
+      QMessageBox::critical(
+        this, "Error",
+        "The temporary project file could not be created. "
+        "Please save the project or try again. "
+        "(" + d->TemporaryProject->errorString() + ")");
+      d->TemporaryProject.reset();
+      return;
+    }
+    d->ProjectPath = d->TemporaryProject->fileName();
+  }
+
+  // Write project file
+  QSettings project{d->ProjectPath, QSettings::IniFormat};
+  project.clear();
+  project.setValue(vpProject::DataSetSpecifierTag, d->UI.dataset->text());
+  project.setValue(vpProject::TracksFileTag, d->UI.tracks->text());
+  project.sync();
+
+  this->accept();
+}
+
+//-----------------------------------------------------------------------------
+void vpProjectEditor::saveProject()
+{
+  const auto& path = vgFileDialog::getSaveFileName(
+    this, "Save Project", {}, "Project files (*.prj);;");
+
+  if (!path.isEmpty())
+  {
+    this->saveProject(path);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void vpProjectEditor::saveProject(const QString& path)
+{
+  QTE_D();
+  d->ProjectPath = path;
+}
+
+//-----------------------------------------------------------------------------
+void vpProjectEditor::browseForDatasetFile()
+{
+  QTE_D();
+
+  const auto& path = vgFileDialog::getOpenFileName(this);
+  if (!path.isEmpty())
+  {
+    d->UI.dataset->setText(path);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void vpProjectEditor::browseForDatasetDirectory()
+{
+  QTE_D();
+
+  const auto& path = vgFileDialog::getExistingDirectory(this);
+  if (!path.isEmpty())
+  {
+    d->UI.dataset->setText(QDir{path}.filePath("*"));
+  }
+}
+
+//-----------------------------------------------------------------------------
+void vpProjectEditor::browseForTracksFile()
+{
+  QTE_D();
+
+  const auto& path = vgFileDialog::getOpenFileName(this);
+  if (!path.isEmpty())
+  {
+    d->UI.tracks->setText(path);
+  }
+}

--- a/Applications/VpView/vpProjectEditor.h
+++ b/Applications/VpView/vpProjectEditor.h
@@ -24,6 +24,8 @@ public:
   QString projectPath() const;
 
 public slots:
+  void setDataset(const QString&);
+
   void saveProject(const QString&);
 
 protected slots:

--- a/Applications/VpView/vpProjectEditor.h
+++ b/Applications/VpView/vpProjectEditor.h
@@ -1,0 +1,45 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __vpProjectEditor_h
+#define __vpProjectEditor_h
+
+#include <QDialog>
+
+#include <qtGlobal.h>
+
+class vpProjectEditorPrivate;
+
+class vpProjectEditor : public QDialog
+{
+  Q_OBJECT
+
+public:
+  vpProjectEditor(QWidget* parent = nullptr, Qt::WindowFlags flags = {});
+  ~vpProjectEditor();
+
+  QString projectPath() const;
+
+public slots:
+  void saveProject(const QString&);
+
+protected slots:
+  void browseForDatasetFile();
+  void browseForDatasetDirectory();
+
+  void browseForTracksFile();
+
+  void saveProject();
+  void acceptProject();
+
+protected:
+  QTE_DECLARE_PRIVATE_RPTR(vpProjectEditor)
+
+private:
+  QTE_DECLARE_PRIVATE(vpProjectEditor)
+};
+
+#endif

--- a/Applications/VpView/vpProjectEditor.ui
+++ b/Applications/VpView/vpProjectEditor.ui
@@ -7,13 +7,16 @@
     <x>0</x>
     <y>0</y>
     <width>463</width>
-    <height>131</height>
+    <height>154</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Configure - VisGUI View</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
    <item row="0" column="0">
     <widget class="QLabel" name="datasetLabel">
      <property name="toolTip">
@@ -106,6 +109,16 @@
     </layout>
    </item>
    <item row="2" column="0" colspan="2">
+    <widget class="QLabel" name="saveInfo">
+     <property name="text">
+      <string>Project will NOT be saved.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -113,12 +126,12 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>448</width>
-       <height>1</height>
+       <height>2000000000</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttons">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/Applications/VpView/vpProjectEditor.ui
+++ b/Applications/VpView/vpProjectEditor.ui
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>vpProjectEditor</class>
+ <widget class="QDialog" name="vpProjectEditor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>463</width>
+    <height>131</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Configure - VisGUI View</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="datasetLabel">
+     <property name="toolTip">
+      <string>Path to the project imagery. This may be an image list file, or a glob expression of image files.</string>
+     </property>
+     <property name="text">
+      <string>&amp;Imagery</string>
+     </property>
+     <property name="buddy">
+      <cstring>dataset</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="datasetLayout">
+     <property name="spacing">
+      <number>2</number>
+     </property>
+     <item>
+      <widget class="QLineEdit" name="dataset">
+       <property name="toolTip">
+        <string>Path to the project imagery. This may be an image list file, or a glob expression of image files.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="pickDataset">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Icons/vpView.qrc">
+         <normaloff>:/icons/16x16/browse</normaloff>:/icons/16x16/browse</iconset>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::InstantPopup</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="tracksLabel">
+     <property name="toolTip">
+      <string>Path to tracks file.</string>
+     </property>
+     <property name="text">
+      <string>&amp;Tracks</string>
+     </property>
+     <property name="buddy">
+      <cstring>tracks</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="tracksLayout">
+     <property name="spacing">
+      <number>2</number>
+     </property>
+     <item>
+      <widget class="QLineEdit" name="tracks">
+       <property name="toolTip">
+        <string>Path to tracks file.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="pickTracks">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../Icons/vpView.qrc">
+         <normaloff>:/icons/16x16/browse</normaloff>:/icons/16x16/browse</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>448</width>
+       <height>1</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttons">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+  <action name="actionDatasetPickFile">
+   <property name="text">
+    <string>Pick &amp;File...</string>
+   </property>
+  </action>
+  <action name="actionDatasetPickDirectory">
+   <property name="text">
+    <string>Pick &amp;Directory...</string>
+   </property>
+  </action>
+ </widget>
+ <resources>
+  <include location="../../Icons/vpView.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>buttons</sender>
+   <signal>rejected()</signal>
+   <receiver>vpProjectEditor</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Applications/VpView/vpView.cxx
+++ b/Applications/VpView/vpView.cxx
@@ -366,7 +366,9 @@ vpView::vpView()
 #endif
 
   // Set up action signals and slots
-  connect(this->Internal->UI.actionOpenFile, SIGNAL(triggered()),
+  connect(this->Internal->UI.actionNewProject, SIGNAL(triggered()),
+          this->Core, SLOT(newProject()));
+  connect(this->Internal->UI.actionOpenProject, SIGNAL(triggered()),
           this->Core, SLOT(openProject()));
   connect(this->Internal->UI.actionImportProject, SIGNAL(triggered()),
           this, SLOT(importProject()));

--- a/Applications/VpView/vpView.ui
+++ b/Applications/VpView/vpView.ui
@@ -118,7 +118,8 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
-    <addaction name="actionOpenFile"/>
+    <addaction name="actionNewProject"/>
+    <addaction name="actionOpenProject"/>
     <addaction name="actionImportProject"/>
     <addaction name="separator"/>
     <addaction name="actionExportTracks"/>
@@ -753,9 +754,9 @@
     </layout>
    </widget>
   </widget>
-  <action name="actionOpenFile">
+  <action name="actionOpenProject">
    <property name="text">
-    <string>&amp;Open Project</string>
+    <string>&amp;Open Project...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -1020,9 +1021,6 @@
    </property>
    <property name="text">
     <string>Object Tags</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+N</string>
    </property>
   </action>
   <action name="actionDisplayFullVolume">
@@ -1560,6 +1558,14 @@
    </property>
    <property name="toolTip">
     <string>Set end frame of filter to current frame</string>
+   </property>
+  </action>
+  <action name="actionNewProject">
+   <property name="text">
+    <string>&amp;New Project...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+N</string>
    </property>
   </action>
  </widget>

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -304,6 +304,12 @@ void vpViewCore::cleanUp()
 void vpViewCore::newProject()
 {
   vpProjectEditor editor{qApp->activeWindow()};
+
+  if (!this->Projects.empty())
+    {
+    editor.setDataset(qtString(this->ImageDataSource->getDataSetSpecifier()));
+    }
+
   if (editor.exec() == QDialog::Accepted)
     {
     if (this->loadProject(qPrintable(editor.projectPath())))

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -28,6 +28,7 @@
 #include "vpNormalcyMaps.h"
 #include "vpObjectInfoPanel.h"
 #include "vpProject.h"
+#include "vpProjectEditor.h"
 #include "vpProjectParser.h"
 #include "vpQtViewer3dWidget.h"
 #include "vpRenderWindowDialog.h"
@@ -300,25 +301,40 @@ void vpViewCore::cleanUp()
 }
 
 //-----------------------------------------------------------------------------
+void vpViewCore::newProject()
+{
+  vpProjectEditor editor{qApp->activeWindow()};
+  if (editor.exec() == QDialog::Accepted)
+    {
+    if (this->loadProject(qPrintable(editor.projectPath())))
+      {
+      // Update view
+      if (this->Projects.size() == 1)
+        {
+        this->refreshView();
+        }
+      }
+    }
+}
+
+//-----------------------------------------------------------------------------
 void vpViewCore::openProject()
 {
-  QString path = vgFileDialog::getOpenFileName(
-    0, "File Open Dialog:", QString(), "vpView project (*.prj);;");
+  const auto& path = vgFileDialog::getOpenFileName(
+    qApp->activeWindow(), "Open Project", {}, "Project files (*.prj);;");
 
   if (path.isEmpty())
     {
     return;
     }
 
-  if (!this->loadProject(qPrintable(path)))
+  if (this->loadProject(qPrintable(path)))
     {
-    return;
-    }
-
-  // Update view.
-  if (this->Projects.size() == 1)
-    {
-    this->refreshView();
+    // Update view
+    if (this->Projects.size() == 1)
+      {
+      this->refreshView();
+      }
     }
 }
 

--- a/Applications/VpView/vpViewCore.h
+++ b/Applications/VpView/vpViewCore.h
@@ -380,7 +380,7 @@ public:
   void toGraphicsCoordinates(double (&xy)[2]);
 
 public slots:
-
+  void newProject();
   void openProject();
   void importProject();
 


### PR DESCRIPTION
Create a rudimentary "project editor" for WAMI Viewer. Use this to allow in-application creation of a new project file, which can be immediately loaded.