### PR TITLE
Add "theming" support

### DIFF
--- a/Applications/Viqui/main.cxx
+++ b/Applications/Viqui/main.cxx
@@ -1,11 +1,10 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
 #include <QtCore>
-#include <QApplication>
 #include <QList>
 #include <QMainWindow>
 #include <QScopedPointer>
@@ -15,6 +14,8 @@
 #include <qtStlUtil.h>
 
 #include <vgCheckArg.h>
+
+#include <vgApplication.h>
 
 #include <vvQuery.h>
 #include <vvQueryResult.h>
@@ -85,8 +86,11 @@ int main(int argc, char** argv)
               " organization's configuration space with those from 'file'");
   args.addOptions(options);
 
+  vgApplication::addCommandLineOptions(args);
+
   // Parse arguments
   args.parseOrDie();
+  vgApplication::parseCommandLine(args);
 
   // Handle various config-related options
   qtUtil::map(args.values("import-config"),
@@ -99,10 +103,8 @@ int main(int argc, char** argv)
               &parseConfigFile, true, true);
 
   // Create application instance and set copyright information
-  QApplication app(args.qtArgc(), args.qtArgv());
-
-  app.setProperty("COPY_YEAR", VIQUI_COPY_YEAR);
-  app.setProperty("COPY_ORGANIZATION", "Kitware, Inc.");
+  vgApplication app(args.qtArgc(), args.qtArgv());
+  app.setCopyright(VIQUI_COPY_YEAR, "Kitware, Inc.");
 
   // Register metatypes
   QTE_REGISTER_METATYPE(vvProcessingRequest);

--- a/Applications/VpView/main.cxx
+++ b/Applications/VpView/main.cxx
@@ -47,8 +47,11 @@ int main(int argc, char** argv)
   options.add("streaming").add("s", "Enable streaming mode");
   args.addOptions(options);
 
+  vgApplication::addCommandLineOptions(args);
+
   // Parse arguments
   args.parseOrDie();
+  vgApplication::parseCommandLine(args);
 
   // Create application instance and set copyright information
   vpApplication app(args.qtArgc(), args.qtArgv());

--- a/Applications/VpView/main.cxx
+++ b/Applications/VpView/main.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -44,9 +44,6 @@ int main(int argc, char** argv)
 
   qtCliOptions options;
   options.add("project <file>").add("p", "Load project 'file'");
-  options.add("config <file>")
-         .add("c", "Use configuration information from 'file'");
-  options.add("reset-config").add("r", "Reset to default settings");
   options.add("streaming").add("s", "Enable streaming mode");
   args.addOptions(options);
 
@@ -55,8 +52,7 @@ int main(int argc, char** argv)
 
   // Create application instance and set copyright information
   vpApplication app(args.qtArgc(), args.qtArgv());
-  app.setProperty("COPY_YEAR", VPVIEW_COPY_YEAR);
-  app.setProperty("COPY_ORGANIZATION", "Kitware, Inc.");
+  app.setCopyright(VPVIEW_COPY_YEAR, "Kitware, Inc.");
 
   vpView myView;
   myView.show();

--- a/Applications/VpView/vpApplication.h
+++ b/Applications/VpView/vpApplication.h
@@ -1,18 +1,16 @@
 #ifndef __vpApplication_h
 #define __vpApplication_h
 
-// Qt includes.
-#include <QApplication>
+#include "vpSettings.h"
 
-// VpView includes.
-#include <vpSettings.h>
+#include <vgApplication.h>
 
-class vpApplication : public QApplication
+class vpApplication : public vgApplication
 {
   Q_OBJECT
 
 public:
-  vpApplication(int& argc, char** argv) : QApplication(argc, argv)
+  vpApplication(int& argc, char** argv) : vgApplication(argc, argv)
     {
     }
 

--- a/Applications/VsPlay/main.cxx
+++ b/Applications/VsPlay/main.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -93,8 +93,11 @@ int main(int argc, char** argv)
   options.add("mask-image <file>", "Mask image to overlay on video");
   args.addOptions(options);
 
+  vgApplication::addCommandLineOptions(args);
+
   // Parse arguments
   args.parseOrDie();
+  vgApplication::parseCommandLine(args);
 
   // Create application instance and set copyright information
   vsApplication app(args.qtArgc(), args.qtArgv());

--- a/Libraries/QtVgWidgets/vgApplication.cxx
+++ b/Libraries/QtVgWidgets/vgApplication.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -9,9 +9,15 @@
 #include "vgAboutAction.h"
 #include "vgUserManualAction.h"
 
+#include <qtCliArgs.h>
+#include <qtColorScheme.h>
+
 #include <QDir>
 #include <QFileInfo>
 #include <QMenu>
+#include <QSettings>
+#include <QStyle>
+#include <QStyleFactory>
 #include <QVariant>
 
 #define WITH_D(type, modifier) \
@@ -191,5 +197,26 @@ void vgApplication::setupHelpMenu(
   if (entries.testFlag(vgApplication::AboutAction))
     {
     menu->addAction(new vgAboutAction(menu));
+    }
+}
+
+//-----------------------------------------------------------------------------
+void vgApplication::addCommandLineOptions(qtCliArgs& args)
+{
+  qtCliOptions options;
+  options.add("theme <file>", "Load application theme from 'file'");
+  args.addOptions(options);
+}
+
+//-----------------------------------------------------------------------------
+void vgApplication::parseCommandLine(qtCliArgs& args)
+{
+  const auto& themeFile = args.value("theme");
+  if (!themeFile.isEmpty())
+    {
+    QSettings settings(themeFile, QSettings::IniFormat);
+
+    QApplication::setStyle(settings.value("WidgetStyle").toString());
+    QApplication::setPalette(qtColorScheme::fromSettings(settings));
     }
 }

--- a/Libraries/QtVgWidgets/vgApplication.h
+++ b/Libraries/QtVgWidgets/vgApplication.h
@@ -15,6 +15,8 @@
 
 class QMenu;
 
+class qtCliArgs;
+
 class vgApplicationPrivate;
 
 /// Base class for ViViA applications.
@@ -120,6 +122,22 @@ public:
   /// menu. This includes activation slots for the actions, i.e. the actions
   /// will function with no additional setup required.
   static void setupHelpMenu(QMenu*, HelpMenuEntries = FullHelpMenu);
+
+  /// Add standard command line options.
+  ///
+  /// This sets up command line options that are shared across various ViViA
+  /// applications.
+  ///
+  /// \sa parseCommandLine()
+  static void addCommandLineOptions(qtCliArgs&);
+
+  /// Handle standard command line options.
+  ///
+  /// This checks the command line parser for the presence of standard command
+  /// line options (as set up by addCommandLineOptions()) and, if present,
+  /// takes appropriate action. Applications should call this function at some
+  /// point after calling qtCliArgs::parse().
+  static void parseCommandLine(qtCliArgs&);
 
 protected:
   QTE_DECLARE_PRIVATE_RPTR(vgApplication)

--- a/Libraries/QtVgWidgets/vgApplication.h
+++ b/Libraries/QtVgWidgets/vgApplication.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2014 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -17,7 +17,7 @@ class QMenu;
 
 class vgApplicationPrivate;
 
-/// Base class for VisGUI applications.
+/// Base class for ViViA applications.
 ///
 /// This class extends QApplication to provide some common properties that are
 /// used by vgAboutDialog and vgUserManualAction.


### PR DESCRIPTION
Make `vpApplication` a `vgApplication`. Modify viqui to use `vgApplication`. Add mechanism to `vgApplication` to load a user-defined "theme" (consisting of a color palette and optional widget style). Modify the main applications to use this.

This adds the ability to override the system color scheme and widget style using the new `--theme` option to specify an alternate "theme" file.