### PR TITLE
 Implement non-VidTK track reader for WAMI Viewer

### DIFF
--- a/Applications/VpView/CMakeLists.txt
+++ b/Applications/VpView/CMakeLists.txt
@@ -228,6 +228,11 @@ if(VISGUI_ENABLE_VIDTK)
     vpVidtkIO.cxx
     vpVidtkTrackIO.cxx
   )
+else()
+  list(APPEND vpViewSources
+    vpVdfIO.cxx
+    vpVdfTrackIO.cxx
+  )
 endif()
 
 # END OPTIONAL vidtk io

--- a/Applications/VpView/vpVdfIO.cxx
+++ b/Applications/VpView/vpVdfIO.cxx
@@ -1,0 +1,118 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "vpVdfIO.h"
+
+#include "vpVdfTrackIO.h"
+
+#include <QUrl>
+
+QTE_IMPLEMENT_D_FUNC(vpVdfIO)
+
+//-----------------------------------------------------------------------------
+class vpVdfEventIO : public vpEventIO
+{
+public:
+  vpVdfEventIO(vtkVgEventModel* eventModel,
+               vtkVgEventTypeRegistry* eventTypes)
+    : vpEventIO{eventModel, eventTypes} {}
+
+  ~vpVdfEventIO() {}
+
+  virtual bool ReadEvents() QTE_OVERRIDE { return false; }
+  virtual bool WriteEvents(const char*) const  QTE_OVERRIDE { return false; }
+};
+
+//-----------------------------------------------------------------------------
+class vpVdfActivityIO : public vpActivityIO
+{
+public:
+  vpVdfActivityIO(vtkVgActivityManager* activityManager,
+                  vpActivityConfig* activityConfig)
+    : vpActivityIO{activityManager, activityConfig} {}
+
+  ~vpVdfActivityIO() {}
+
+  virtual bool ReadActivities() QTE_OVERRIDE { return false; }
+};
+
+//-----------------------------------------------------------------------------
+class vpVdfIOPrivate
+{
+public:
+  unsigned int ImageHeight;
+  QUrl TracksUri;
+};
+
+//-----------------------------------------------------------------------------
+vpVdfIO::vpVdfIO() : d_ptr{new vpVdfIOPrivate}
+{
+  QTE_D(vpVdfIO);
+
+  d->ImageHeight = 0;
+}
+
+//-----------------------------------------------------------------------------
+vpVdfIO::~vpVdfIO()
+{
+}
+
+//-----------------------------------------------------------------------------
+void vpVdfIO::SetTrackModel(
+  vtkVpTrackModel* trackModel,
+  vpTrackIO::TrackStorageMode storageMode,
+  vpTrackIO::TrackTimeStampMode timeStampMode,
+  vtkVgTrackTypeRegistry* trackTypes,
+  vtkMatrix4x4* geoTransform, vpFrameMap* frameMap)
+{
+  QTE_D();
+
+  auto* const trackIO =
+    new vpVdfTrackIO{this, trackModel, storageMode, timeStampMode,
+                     trackTypes, geoTransform, frameMap};
+  this->TrackIO.reset(trackIO);
+
+  trackIO->SetTracksUri(d->TracksUri);
+}
+
+//-----------------------------------------------------------------------------
+void vpVdfIO::SetEventModel(vtkVgEventModel* eventModel,
+                            vtkVgEventTypeRegistry* eventTypes)
+{
+  this->EventIO.reset(new vpVdfEventIO{eventModel, eventTypes});
+}
+
+//-----------------------------------------------------------------------------
+void vpVdfIO::SetActivityModel(vtkVgActivityManager* activityManager,
+                               vpActivityConfig* activityConfig)
+{
+  this->ActivityIO.reset(new vpVdfActivityIO{activityManager, activityConfig});
+}
+
+//-----------------------------------------------------------------------------
+void vpVdfIO::SetImageHeight(unsigned int imageHeight)
+{
+  QTE_D();
+  d->ImageHeight = imageHeight;
+}
+
+//-----------------------------------------------------------------------------
+unsigned int vpVdfIO::GetImageHeight() const
+{
+  QTE_D();
+  return d->ImageHeight;
+}
+
+//-----------------------------------------------------------------------------
+void vpVdfIO::SetTracksUri(const QUrl& uri)
+{
+  QTE_D();
+  d->TracksUri = uri;
+  if (auto* const trackIO = dynamic_cast<vpVdfTrackIO*>(this->TrackIO.get()))
+    {
+    trackIO->SetTracksUri(uri);
+    }
+}

--- a/Applications/VpView/vpVdfIO.h
+++ b/Applications/VpView/vpVdfIO.h
@@ -1,0 +1,50 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __vpVdfIO_h
+#define __vpVdfIO_h
+
+#include "vpModelIO.h"
+
+#include <qtGlobal.h>
+
+#include <QUrl>
+
+class vpVdfIOPrivate;
+
+class vpVdfIO : public vpModelIO
+{
+public:
+  vpVdfIO();
+  virtual ~vpVdfIO();
+
+  virtual void SetTrackModel(vtkVpTrackModel* trackModel,
+                             vpTrackIO::TrackStorageMode storageMode,
+                             vpTrackIO::TrackTimeStampMode timeStampMode,
+                             vtkVgTrackTypeRegistry* trackTypes,
+                             vtkMatrix4x4* geoTransform,
+                             vpFrameMap* frameMap) QTE_OVERRIDE;
+
+  virtual void SetEventModel(vtkVgEventModel* eventModel,
+                             vtkVgEventTypeRegistry* eventTypes) QTE_OVERRIDE;
+
+  virtual void SetActivityModel(vtkVgActivityManager* activityManager,
+                                vpActivityConfig* activityConfig) QTE_OVERRIDE;
+
+  virtual void SetImageHeight(unsigned int imageHeight) QTE_OVERRIDE;
+  virtual unsigned int GetImageHeight() const QTE_OVERRIDE;
+
+  void SetTracksUri(const QUrl& uri);
+
+protected:
+  QTE_DECLARE_PRIVATE_RPTR(vpVdfIO);
+
+private:
+  QTE_DECLARE_PRIVATE(vpVdfIO);
+  QTE_DISABLE_COPY(vpVdfIO);
+};
+
+#endif

--- a/Applications/VpView/vpVdfTrackIO.cxx
+++ b/Applications/VpView/vpVdfTrackIO.cxx
@@ -1,0 +1,266 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "vpVdfTrackIO.h"
+
+#include "vpFrameMap.h"
+#include "vpVdfIO.h"
+#include "vtkVpTrackModel.h"
+
+#include <vdfDataSource.h>
+#include <vdfSourceService.h>
+#include <vdfTrackReader.h>
+
+#include <qtEnumerate.h>
+#include <qtStlUtil.h>
+
+#include <vtksys/Glob.hxx>
+
+#include <QUrl>
+
+namespace
+{
+
+//-----------------------------------------------------------------------------
+void addPoint(std::vector<float>& points, float x, float y, float z = 0.0f)
+{
+  points.push_back(x);
+  points.push_back(y);
+  points.push_back(z);
+}
+
+} // namespace <anonymous>
+
+QTE_IMPLEMENT_D_FUNC(vpVdfTrackIO)
+
+//-----------------------------------------------------------------------------
+class vpVdfTrackIOPrivate
+{
+public:
+  vpVdfIO* Base;
+  QUrl TracksUri;
+};
+
+//-----------------------------------------------------------------------------
+vpVdfTrackIO::vpVdfTrackIO(
+  vpVdfIO* base, vtkVpTrackModel* trackModel,
+  TrackStorageMode storageMode, TrackTimeStampMode timeStampMode,
+  vtkVgTrackTypeRegistry* trackTypes, vtkMatrix4x4* geoTransform,
+  vpFrameMap* frameMap)
+  : vpTrackIO{trackModel, storageMode, timeStampMode,
+              trackTypes, geoTransform, frameMap},
+    d_ptr{new vpVdfTrackIOPrivate}
+{
+  QTE_D();
+  d->Base = base;
+}
+
+//-----------------------------------------------------------------------------
+vpVdfTrackIO::~vpVdfTrackIO()
+{
+}
+
+//-----------------------------------------------------------------------------
+unsigned int vpVdfTrackIO::GetImageHeight() const
+{
+  QTE_D();
+  return d->Base->GetImageHeight();
+}
+
+//-----------------------------------------------------------------------------
+void vpVdfTrackIO::SetTracksUri(const QUrl& uri)
+{
+  QTE_D();
+  d->TracksUri = uri;
+}
+
+//-----------------------------------------------------------------------------
+bool vpVdfTrackIO::ReadTracks()
+{
+  QTE_D();
+
+  vdfTrackReader reader;
+
+  if (d->TracksUri.isLocalFile())
+    {
+    // Interpret the specifier as a glob
+    vtksys::Glob glob;
+    glob.FindFiles(stdString(d->TracksUri.toLocalFile()));
+    glob.SetRecurse(true);
+    const auto& files = glob.GetFiles();
+    if (files.empty())
+      {
+      return false;
+      }
+
+    // Read through each track file
+    for (size_t i = 0, k = files.size(); i < k; ++i)
+      {
+      // Construct the track source and track reader
+      const auto& trackUri = QUrl::fromLocalFile(qtString(files[i]));
+      QScopedPointer<vdfDataSource> source{
+        vdfSourceService::createArchiveSource(trackUri)};
+
+      if (source)
+        {
+        reader.setSource(source.data());
+
+        // Read tracks
+        if (!reader.exec() && reader.failed())
+          {
+          // Track reading failed; die
+          return false;
+          }
+        }
+      }
+    }
+  else
+    {
+    // Construct the track source and track reader
+    QScopedPointer<vdfDataSource> source{
+      vdfSourceService::createArchiveSource(d->TracksUri)};
+
+    if (source)
+      {
+      reader.setSource(source.data());
+
+      // Read tracks
+      if (!reader.exec() && reader.failed())
+        {
+        // Track reading failed; die
+        return false;
+        }
+      }
+    }
+
+
+  if (!reader.hasData())
+    {
+    // No data was obtained; die
+    return false;
+    }
+
+  const auto& inTracks = reader.tracks();
+  foreach (const auto& ti, qtEnumerate(inTracks))
+    {
+    const vdfTrackReader::Track& in = ti.value();
+
+    auto* const track = vtkVgTrack::New();
+    track->InterpolateMissingPointsOnInsertOn();
+    track->SetPoints(this->TrackModel->GetPoints());
+
+    // Set track model identifier
+    const auto vtkId = static_cast<vtkIdType>(ti.key().SerialNumber);
+    if (this->TrackModel->GetTrack(vtkId))
+      {
+      const auto fallbackId = this->TrackModel->GetNextAvailableId();
+      std::cout << "Track id " << vtkId
+                << " is not unique: changing id of imported track to "
+                << fallbackId << std::endl;
+      track->SetId(fallbackId);
+      }
+    else
+      {
+      track->SetId(vtkId);
+      }
+
+    // Set track type classifiers
+    if (!in.Classification.empty())
+      {
+      std::map<int, double> toc;
+      foreach (const auto& c, in.Classification)
+        {
+        toc.emplace(this->GetTrackTypeIndex(c.first.c_str()), c.second);
+        }
+      track->SetTOC(toc);
+      }
+
+    // Iterate over track states
+    foreach (const auto& s, in.Trajectory)
+      {
+      // Get frame metadata
+      QScopedPointer<vpFrame> frame;
+      if (this->FrameMap)
+        {
+        frame.reset(new vpFrame);
+        if (!this->FrameMap->getFrame(s.TimeStamp.FrameNumber, *frame))
+          {
+          frame.reset();
+          }
+        }
+
+      // Extract time stamp
+      auto ts = vtkVgTimeStamp{s.TimeStamp};
+      if (!ts.HasTime() && frame)
+        {
+        ts = frame->Time;
+        }
+
+      // Extract point location
+      double p[4] = {s.ImagePoint.X, s.ImagePoint.Y, 0.0, 1.0};
+      if (this->StorageMode == TSM_InvertedImageCoords)
+        {
+        p[1] = this->GetImageHeight() - p[1];
+        }
+      else if (this->StorageMode == TSM_HomographyTransformedImageCoords)
+        {
+        if (!frame || !frame->Homography)
+          {
+          std::cerr << "ERROR: Homgraphy for frame " << ts.GetFrameNumber()
+                    << "is unavailable.  Track point not added!\n";
+          continue;
+          }
+        else
+          {
+          frame->Homography->MultiplyPoint(p, p);
+          p[0] /= p[3];
+          p[1] /= p[3];
+          }
+        }
+
+      // Extract shell points
+      std::vector<float> shell;
+      if (s.ImageObject.empty())
+        {
+        shell.reserve(12);
+        const auto& tl = s.ImageBox.TopLeft;
+        const auto& br = s.ImageBox.BottomRight;
+        addPoint(shell, tl.X, tl.Y);
+        addPoint(shell, tl.X, br.Y);
+        addPoint(shell, br.X, br.Y);
+        addPoint(shell, br.X, tl.Y);
+        }
+      else
+        {
+        shell.reserve(3 * s.ImageObject.size());
+        foreach (const auto& sp, s.ImageObject)
+          {
+          const auto x = static_cast<float>(sp.X);
+          const auto y = static_cast<float>(sp.Y);
+          addPoint(shell, x, y);
+          }
+        }
+
+      // Adjust shell points for storage mode
+      if (this->StorageMode == TSM_InvertedImageCoords)
+        {
+        const auto imageHeight = static_cast<float>(this->GetImageHeight());
+        for (size_t i = 1; i < shell.size(); i += 3)
+          {
+          shell[i] = imageHeight - shell[i];
+          }
+        }
+
+      track->InsertNextPoint(ts, p, s.WorldLocation,
+                             shell.size() / 3, shell.data());
+      }
+
+    track->Close();
+    this->AddTrack(track);
+    }
+
+  return true;
+}

--- a/Applications/VpView/vpVdfTrackIO.h
+++ b/Applications/VpView/vpVdfTrackIO.h
@@ -1,0 +1,49 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __vpVdfTrackIO_h
+#define __vpVdfTrackIO_h
+
+#include "vpTrackIO.h"
+
+#include <qtGlobal.h>
+
+#include <QScopedPointer>
+
+class QUrl;
+
+class vpVdfIO;
+
+class vpVdfTrackIOPrivate;
+
+class vpVdfTrackIO : public vpTrackIO
+{
+public:
+  vpVdfTrackIO(
+    vpVdfIO* base, vtkVpTrackModel* trackModel,
+    TrackStorageMode storageMode, TrackTimeStampMode timeStampMode,
+    vtkVgTrackTypeRegistry* trackTypes, vtkMatrix4x4* geoTransform,
+    vpFrameMap* frameMap);
+
+  virtual ~vpVdfTrackIO();
+
+  void SetTracksUri(const QUrl&);
+
+  virtual bool ReadTracks() QTE_OVERRIDE;
+  virtual bool WriteTracks(const char*, bool) const QTE_OVERRIDE
+    { return false; }
+
+protected:
+  QTE_DECLARE_PRIVATE_RPTR(vpVdfTrackIO);
+
+  virtual unsigned int GetImageHeight() const;
+
+private:
+  QTE_DECLARE_PRIVATE(vpVdfTrackIO);
+  QTE_DISABLE_COPY(vpVdfTrackIO);
+};
+
+#endif

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -40,6 +40,8 @@
 
 #ifdef VISGUI_USE_VIDTK
 #include "vpVidtkFileIO.h"
+#else
+#include "vpVdfIO.h"
 #endif
 
 #ifdef VISGUI_USE_KWIVER
@@ -2976,9 +2978,10 @@ vpProject* vpViewCore::loadProject(const char* fileName)
   project->ModelIO = fileIO;
   return this->processProject(project);
 #else
-  QMessageBox::warning(0, QString(),
-                       "Cannot open project files without VidTK support.");
-  return 0;
+  QSharedPointer<vpVdfIO> io{new vpVdfIO};
+  io->SetTracksUri(QUrl::fromUserInput(project->TracksFile));
+  project->ModelIO = io;
+  return this->processProject(project);
 #endif
 }
 

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -2967,7 +2967,14 @@ vpProject* vpViewCore::loadProject(const char* fileName)
   QScopedPointer<vpProject> project(new vpProject(this->CurrentProjectId++));
   this->ProjectParser->Parse(project.data());
 
+  return this->loadProject(project);
+}
+
+//-----------------------------------------------------------------------------
+vpProject* vpViewCore::loadProject(QScopedPointer<vpProject>& project)
+{
 #ifdef VISGUI_USE_VIDTK
+
   QSharedPointer<vpVidtkFileIO> fileIO(new vpVidtkFileIO);
   fileIO->SetTracksFileName(qPrintable(project->TracksFile));
   fileIO->SetTrackTraitsFileName(qPrintable(project->TrackTraitsFile));
@@ -2976,13 +2983,16 @@ vpProject* vpViewCore::loadProject(const char* fileName)
   fileIO->SetActivitiesFileName(qPrintable(project->ActivitiesFile));
   fileIO->SetFseTracksFileName(qPrintable(project->SceneElementsFile));
   project->ModelIO = fileIO;
-  return this->processProject(project);
+
 #else
+
   QSharedPointer<vpVdfIO> io{new vpVdfIO};
   io->SetTracksUri(QUrl::fromUserInput(project->TracksFile));
   project->ModelIO = io;
-  return this->processProject(project);
+
 #endif
+
+  return this->processProject(project);
 }
 
 //-----------------------------------------------------------------------------
@@ -8640,18 +8650,5 @@ void vpViewCore::reactToExternalProcessFileChanged(QString changedFile)
     emit removeAllFilters();
     }
 
-#ifdef VISGUI_USE_VIDTK
-  QSharedPointer<vpVidtkFileIO> fileIO(new vpVidtkFileIO);
-  fileIO->SetTracksFileName(qPrintable(project->TracksFile));
-  fileIO->SetTrackTraitsFileName(qPrintable(project->TrackTraitsFile));
-  fileIO->SetEventsFileName(qPrintable(project->EventsFile));
-  fileIO->SetEventLinksFileName(qPrintable(project->EventLinksFile));
-  fileIO->SetActivitiesFileName(qPrintable(project->ActivitiesFile));
-  fileIO->SetFseTracksFileName(qPrintable(project->SceneElementsFile));
-  project->ModelIO = fileIO;
-  this->processProject(project);
-#else
-  QMessageBox::warning(0, QString(),
-                       "Cannot open project files without VidTK support.");
-#endif
+  this->loadProject(project);
 }

--- a/Applications/VpView/vpViewCore.h
+++ b/Applications/VpView/vpViewCore.h
@@ -698,6 +698,8 @@ private:
 
   void initializeImageSource();
 
+  vpProject* loadProject(QScopedPointer<vpProject>& project);
+
   void addEvents(vpProject* project);
   void removeEvents(vpProject* project);
   void addTrackHeads(vpProject* project);


### PR DESCRIPTION
Create an I/O implementation for WAMI Viewer that uses exclusively the data frameworks (`vdfSourceService`) and does not depend on VidTK in any fashion. (`vpVidtkFileReader` also uses `vdfSourceService`, but had a fallback to VidTK's track reader process, and the retrieved tracks were first wrapped in VidTK tracks; this new implementation cuts out that step.) For now, only initial track reading is supported. Events, activities, and importing are not supported.

This implementation also does not support the various ancillary files that have sprouted up, but that is probably The Right Thing To Do anyway; if we continue to support such things, they should be handled at the reader plugin level, rather than partly at the application level, as is being done currently.

This should make it possible to read tracks using track_oracle from [KWIVER](https://github.com/kitware/kwiver). Combined with the (somewhat) recent project refactoring, this should finally produce a WAMI Viewer that is at least somewhat usable without VidTK.