### PR TITLE
Add support for KWIVER embedded pipelines to WAMI Viewer

### DIFF
--- a/Applications/VpView/CMakeLists.txt
+++ b/Applications/VpView/CMakeLists.txt
@@ -243,11 +243,13 @@ endif()
 
 if(VISGUI_ENABLE_KWIVER)
   list(APPEND vpViewSources
+    vpKwiverEmbeddedPipelineWorker.cxx
     vpKwiverImproveTrackWorker.cxx
     vpKwiverVideoSource.cxx
   )
 
   list(APPEND vpViewHeaders
+    vpKwiverEmbeddedPipelineWorker.h
     vpKwiverImproveTrackWorker.h
   )
 endif()
@@ -303,6 +305,8 @@ target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
 
 if(VISGUI_ENABLE_KWIVER)
   target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
+    kwiver::sprokit_tools
+    kwiver::kwiver_adapter
     kwiver::kwiver_algo_vxl
     kwiver::kwiver_algo_core
   )

--- a/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
+++ b/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
@@ -18,6 +18,7 @@
 #include <QEventLoop>
 #include <QFileInfo>
 #include <QMessageBox>
+#include <QProgressDialog>
 #include <QThread>
 
 #include <sprokit/processes/adapters/embedded_pipeline.h>
@@ -55,6 +56,7 @@ public:
   kwiver::embedded_pipeline pipeline;
 
   std::atomic<bool> canceled = {false};
+  QScopedPointer<QProgressDialog> cancelDialog;
 
   QString error;
 
@@ -200,5 +202,12 @@ void vpKwiverEmbeddedPipelineWorker::execute()
 void vpKwiverEmbeddedPipelineWorker::cancel()
 {
   QTE_D();
+
   d->canceled = true;
+
+  d->cancelDialog.reset(new QProgressDialog);
+  d->cancelDialog->setLabelText("Canceling...");
+  d->cancelDialog->setCancelButton(nullptr);
+  d->cancelDialog->setRange(0, 0);
+  d->cancelDialog->show();
 }

--- a/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
+++ b/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
@@ -1,0 +1,204 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "vpKwiverEmbeddedPipelineWorker.h"
+
+#include "vpFileDataSource.h"
+#include "vtkVpTrackModel.h"
+
+#include <vtkVgTrack.h>
+
+#include <qtIndexRange.h>
+#include <qtStlUtil.h>
+
+#include <QApplication>
+#include <QEventLoop>
+#include <QFileInfo>
+#include <QMessageBox>
+#include <QThread>
+
+#include <sprokit/processes/adapters/embedded_pipeline.h>
+
+#include <arrows/vxl/image_io.h>
+
+#include <atomic>
+#include <functional>
+
+namespace kv = kwiver::vital;
+
+namespace
+{
+
+//-----------------------------------------------------------------------------
+template <typename T, typename K>
+const T* get(const std::vector<T>& c, K const& key)
+{
+  auto const iter = std::find(c.begin(), c.end(), T{key});
+  return (iter == c.end() ? nullptr : std::addressof(*iter));
+}
+
+}
+
+//-----------------------------------------------------------------------------
+class vpKwiverEmbeddedPipelineWorkerPrivate : public QThread
+{
+public:
+  vpKwiverEmbeddedPipelineWorkerPrivate(vpKwiverEmbeddedPipelineWorker* q)
+  : q_ptr{q} {}
+
+  std::vector<std::string> framePaths;
+
+  kwiver::arrows::vxl::image_io loader;
+  kwiver::embedded_pipeline pipeline;
+
+  std::atomic<bool> canceled = {false};
+
+  QString error;
+
+protected:
+  QTE_DECLARE_PUBLIC_PTR(vpKwiverEmbeddedPipelineWorker)
+
+  virtual void run() override;
+
+private:
+  QTE_DECLARE_PUBLIC(vpKwiverEmbeddedPipelineWorker)
+};
+
+QTE_IMPLEMENT_D_FUNC(vpKwiverEmbeddedPipelineWorker)
+
+//-----------------------------------------------------------------------------
+void vpKwiverEmbeddedPipelineWorkerPrivate::run()
+{
+  QTE_Q();
+
+  const auto totalFrames = this->framePaths.size();
+  emit q->progressRangeChanged(0, static_cast<int>(totalFrames));
+  emit q->progressValueChanged(0);
+
+  const auto ports = this->pipeline.input_port_names();
+  const auto image_port = get(ports, "image");
+  const auto timestamp_port = get(ports, "timestamp");
+
+  for (auto currentFrame : qtIndexRange(totalFrames))
+  {
+    if (this->canceled)
+    {
+      break;
+    }
+
+    // Build input data set
+    auto ids = kwiver::adapter::adapter_data_set::create();
+
+    if (image_port)
+    {
+      auto frameImage = this->loader.load(
+        this->framePaths[currentFrame]);
+
+      ids->add_value(*image_port, frameImage);
+    }
+
+    if (timestamp_port)
+    {
+      auto ts = kv::timestamp{};
+      ts.set_frame(static_cast<kv::frame_id_t>(currentFrame));
+
+      ids->add_value(*timestamp_port, ts);
+    }
+
+    // Step pipeline
+    this->pipeline.send(ids);
+    const auto& ods = this->pipeline.receive();
+
+    if (ods->is_end_of_data())
+    {
+      this->error = "Pipeline shut down unexpectedly";
+      return;
+    }
+
+    // Report progress
+    emit q->progressValueChanged(static_cast<int>(currentFrame));
+
+    // TODO do something with data received
+  }
+
+  this->pipeline.send_end_of_input();
+  this->pipeline.wait();
+}
+
+//-----------------------------------------------------------------------------
+vpKwiverEmbeddedPipelineWorker::vpKwiverEmbeddedPipelineWorker(
+  QObject* parent) :
+  QObject{parent}, d_ptr{new vpKwiverEmbeddedPipelineWorkerPrivate{this}}
+{
+}
+
+//-----------------------------------------------------------------------------
+vpKwiverEmbeddedPipelineWorker::~vpKwiverEmbeddedPipelineWorker()
+{
+}
+
+//-----------------------------------------------------------------------------
+bool vpKwiverEmbeddedPipelineWorker::initialize(
+  const QString& pipelineFile, vpFileDataSource* dataSource,
+  const vtkVpTrackModel* trackModel)
+{
+  QTE_D();
+
+  // Copy inputs
+  for (const auto i : qtIndexRange(dataSource->getFileCount()))
+  {
+    d->framePaths.push_back(dataSource->getDataFile(i));
+  }
+
+  // Set up pipeline
+  try
+  {
+    const auto& pipelineDir = QFileInfo{pipelineFile}.canonicalPath();
+
+    std::ifstream pipelineStream;
+    pipelineStream.open(stdString(pipelineFile), std::ifstream::in);
+    if (!pipelineStream)
+    {
+      QMessageBox::warning(qApp->activeWindow(), "Pipeline Error",
+                           "Failed to initialize pipeline: pipeline file '" +
+                           pipelineFile + "' could not be read");
+      return false;
+    }
+
+    d->pipeline.build_pipeline(pipelineStream, stdString(pipelineDir));
+    d->pipeline.start();
+  }
+  catch (std::exception& e)
+  {
+    QMessageBox::warning(qApp->activeWindow(), "Pipeline Error",
+                         "Failed to initialize pipeline: " +
+                         QString::fromLocal8Bit(e.what()));
+    return false;
+  }
+
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+void vpKwiverEmbeddedPipelineWorker::execute()
+{
+  QTE_D();
+
+  QEventLoop loop;
+
+  connect(d, SIGNAL(finished()), &loop, SLOT(quit()));
+
+  d->start();
+  loop.exec();
+  d->wait();
+}
+
+//-----------------------------------------------------------------------------
+void vpKwiverEmbeddedPipelineWorker::cancel()
+{
+  QTE_D();
+  d->canceled = true;
+}

--- a/Applications/VpView/vpKwiverEmbeddedPipelineWorker.h
+++ b/Applications/VpView/vpKwiverEmbeddedPipelineWorker.h
@@ -11,6 +11,16 @@
 
 #include <QObject>
 
+#include <memory>
+
+namespace kwiver
+{
+namespace vital
+{
+class object_track_set;
+}
+}
+
 class vpFileDataSource;
 class vtkVpTrackModel;
 
@@ -26,6 +36,8 @@ public:
 
   bool initialize(const QString& pipelineFile, vpFileDataSource* dataSource,
                   const vtkVpTrackModel* trackModel);
+
+  std::shared_ptr<kwiver::vital::object_track_set> tracks() const;
 
 public slots:
   void execute();

--- a/Applications/VpView/vpKwiverEmbeddedPipelineWorker.h
+++ b/Applications/VpView/vpKwiverEmbeddedPipelineWorker.h
@@ -1,0 +1,45 @@
+/*ckwg +5
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#ifndef __vpKwiverEmbeddedPipelineWorker_h
+#define __vpKwiverEmbeddedPipelineWorker_h
+
+#include <qtGlobal.h>
+
+#include <QObject>
+
+class vpFileDataSource;
+class vtkVpTrackModel;
+
+class vpKwiverEmbeddedPipelineWorkerPrivate;
+
+class vpKwiverEmbeddedPipelineWorker : public QObject
+{
+  Q_OBJECT
+
+public:
+  vpKwiverEmbeddedPipelineWorker(QObject* parent = nullptr);
+  ~vpKwiverEmbeddedPipelineWorker();
+
+  bool initialize(const QString& pipelineFile, vpFileDataSource* dataSource,
+                  const vtkVpTrackModel* trackModel);
+
+public slots:
+  void execute();
+  void cancel();
+
+signals:
+  void progressRangeChanged(int minimum, int maximum);
+  void progressValueChanged(int value);
+
+protected:
+  QTE_DECLARE_PRIVATE_RPTR(vpKwiverEmbeddedPipelineWorker)
+
+private:
+  QTE_DECLARE_PRIVATE(vpKwiverEmbeddedPipelineWorker)
+};
+
+#endif

--- a/Applications/VpView/vpKwiverEmbeddedPipelineWorker.h
+++ b/Applications/VpView/vpKwiverEmbeddedPipelineWorker.h
@@ -35,7 +35,7 @@ public:
   ~vpKwiverEmbeddedPipelineWorker();
 
   bool initialize(const QString& pipelineFile, vpFileDataSource* dataSource,
-                  const vtkVpTrackModel* trackModel);
+                  vtkVpTrackModel* trackModel, double videoHeight);
 
   std::shared_ptr<kwiver::vital::object_track_set> tracks() const;
 

--- a/Applications/VpView/vpView.cxx
+++ b/Applications/VpView/vpView.cxx
@@ -806,11 +806,12 @@ vpView::vpView()
   connect(this->Internal->EmbeddedPipelineMapper, SIGNAL(mapped(QString)),
           this, SLOT(executeEmbeddedPipeline(QString)));
 
-  for (auto i : qtIndexRange(settings.beginReadArray("EmbeddedPipelines")))
+  QSettings config;
+  for (auto i : qtIndexRange(config.beginReadArray("EmbeddedPipelines")))
     {
-    settings.setArrayIndex(i);
-    const auto& name = settings.value("Name").toString();
-    const auto& path = settings.value("Path").toString();
+    config.setArrayIndex(i);
+    const auto& name = config.value("Name").toString();
+    const auto& path = config.value("Path").toString();
     if (!name.isEmpty() && !path.isEmpty())
       {
       this->Internal->UI.actionPipelinePlaceholder->setVisible(false);
@@ -821,7 +822,7 @@ vpView::vpView()
               this->Internal->EmbeddedPipelineMapper, SLOT(map()));
       }
     }
-  settings.endArray();
+  config.endArray();
 #endif
   this->Internal->UI.menuPipeline->setEnabled(false);
 }

--- a/Applications/VpView/vpView.cxx
+++ b/Applications/VpView/vpView.cxx
@@ -4,21 +4,6 @@
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include <QClipboard>
-#include <QComboBox>
-#include <QDoubleSpinBox>
-#include <QEventLoop>
-#include <QFileDialog>
-#include <QInputDialog>
-#include <QMessageBox>
-#include <QSettings>
-#include <QSlider>
-#include <QSplitter>
-#include <QTimer>
-#include <QTreeWidget>
-#include <QVBoxLayout>
-#include <QWidget>
-
 #include "ui_vpView.h"
 
 #include "vpApplication.h"
@@ -62,6 +47,22 @@
 #include <qtStlUtil.h>
 #include <qtUtil.h>
 
+#include <QClipboard>
+#include <QComboBox>
+#include <QDoubleSpinBox>
+#include <QEventLoop>
+#include <QFileDialog>
+#include <QInputDialog>
+#include <QMessageBox>
+#include <QSettings>
+#include <QSignalMapper>
+#include <QSlider>
+#include <QSplitter>
+#include <QTimer>
+#include <QTreeWidget>
+#include <QVBoxLayout>
+#include <QWidget>
+
 //-----------------------------------------------------------------------------
 class vpView::vtkInternal
 {
@@ -82,6 +83,8 @@ public:
   bool DisableFilterPresetUpdates;
 
   QComboBox* executeModeCombo;
+
+  QSignalMapper* EmbeddedPipelineMapper;
 
   QLabel* Coordinates;
   QLabel* Gsd;
@@ -796,6 +799,31 @@ vpView::vpView()
   this->restoreGeometry(settings.value("geometry").toByteArray());
   this->restoreState(settings.value("state").toByteArray());
   settings.endGroup();
+
+#ifdef VISGUI_USE_KWIVER
+  // Set up KWIVER embedded pipelines
+  this->Internal->EmbeddedPipelineMapper = new QSignalMapper{this};
+  connect(this->Internal->EmbeddedPipelineMapper, SIGNAL(mapped(QString)),
+          this, SLOT(executeEmbeddedPipeline(QString)));
+
+  for (auto i : qtIndexRange(settings.beginReadArray("EmbeddedPipelines")))
+    {
+    settings.setArrayIndex(i);
+    const auto& name = settings.value("Name").toString();
+    const auto& path = settings.value("Path").toString();
+    if (!name.isEmpty() && !path.isEmpty())
+      {
+      this->Internal->UI.actionPipelinePlaceholder->setVisible(false);
+      auto pipelineAction = new QAction{name, this};
+      this->Internal->UI.menuPipeline->addAction(pipelineAction);
+      this->Internal->EmbeddedPipelineMapper->setMapping(pipelineAction, path);
+      connect(pipelineAction, SIGNAL(triggered()),
+              this->Internal->EmbeddedPipelineMapper, SLOT(map()));
+      }
+    }
+  settings.endArray();
+#endif
+  this->Internal->UI.menuPipeline->setEnabled(false);
 }
 
 //-----------------------------------------------------------------------------
@@ -829,6 +857,7 @@ void vpView::onDataLoaded()
 
   this->Internal->UI.menuCamera->setEnabled(true);
   this->Internal->UI.menuEventDisplay->setEnabled(true);
+  this->Internal->UI.menuPipeline->setEnabled(true);
   this->Internal->UI.actionRandomEventColors->setEnabled(true);
   this->Internal->UI.actionChangeTrackColors->setEnabled(true);
   this->Internal->UI.actionPreviousAttribute->setEnabled(true);
@@ -1554,6 +1583,13 @@ void vpView::executeExternalProcess()
   this->Core->startExternalProcess(settings.externalProcessProgram(),
                                    settings.externalProcessArgs(),
                                    settings.externalProcessIOPath());
+}
+
+//-----------------------------------------------------------------------------
+void vpView::executeEmbeddedPipeline(const QString& pipelinePath)
+{
+  const auto session = this->Internal->UI.sessionView->GetCurrentSession();
+  this->Core->executeEmbeddedPipeline(session, pipelinePath);
 }
 
 //-----------------------------------------------------------------------------

--- a/Applications/VpView/vpView.h
+++ b/Applications/VpView/vpView.h
@@ -194,6 +194,7 @@ public slots:
   void pickTimeInterval();
 
   void executeExternalProcess();
+  void executeEmbeddedPipeline(const QString& pipelinePath);
 
   void updateTrackFilters();
 

--- a/Applications/VpView/vpView.ui
+++ b/Applications/VpView/vpView.ui
@@ -199,6 +199,12 @@
      <addaction name="separator"/>
      <addaction name="actionMergeTracks"/>
     </widget>
+    <widget class="QMenu" name="menuPipeline">
+     <property name="title">
+      <string>Execute &amp;Pipeline</string>
+     </property>
+     <addaction name="actionPipelinePlaceholder"/>
+    </widget>
     <addaction name="actionConfigure"/>
     <addaction name="actionDatabaseQuery"/>
     <addaction name="separator"/>
@@ -207,6 +213,7 @@
     <addaction name="actionAdjudicationMode"/>
     <addaction name="actionExitFollowMode"/>
     <addaction name="separator"/>
+    <addaction name="menuPipeline"/>
     <addaction name="actionExternalProcess"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -1566,6 +1573,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+N</string>
+   </property>
+  </action>
+  <action name="actionPipelinePlaceholder">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>(No pipelines configured)</string>
    </property>
   </action>
  </widget>

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -1113,7 +1113,8 @@ void vpViewCore::updateTrack(
       narrow(bbox.max_x()), narrow(videoHeight - bbox.min_y()), 0.0f
     }};
 
-    const auto& center = bbox.center();
+    auto center = bbox.center();
+    center[1] = videoHeight - center[1];
 
     track->SetPoint(ts, center.data(), {}, 4, points.data());
 

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -1051,10 +1051,28 @@ void vpViewCore::improveTrack(int trackId, int session)
 }
 
 //-----------------------------------------------------------------------------
+int vpViewCore::getTrackTypeIndex(const char* typeName)
+{
+  const auto index = this->TrackTypeRegistry->GetTypeIndex(typeName);
+
+  if (index >= 0)
+    {
+    return index;
+    }
+
+  vgTrackType type;
+  type.SetId(typeName);
+  type.SetColor(0.5, 0.5, 0.0);
+
+  this->TrackTypeRegistry->AddType(type);
+  return this->TrackTypeRegistry->GetTypeIndex(typeName);
+}
+
+//-----------------------------------------------------------------------------
 void vpViewCore::updateTrack(
   vtkVgTrack* track, const std::shared_ptr<kv::track>& kwiverTrack,
   const std::map<unsigned int, vgTimeStamp>& timeMap,
-  double videoHeight)
+  double videoHeight, bool updateToc)
 {
 #ifdef VISGUI_USE_KWIVER
   for (auto state : *kwiverTrack | kv::as_object_track)
@@ -1098,6 +1116,19 @@ void vpViewCore::updateTrack(
     const auto& center = bbox.center();
 
     track->SetPoint(ts, center.data(), {}, 4, points.data());
+
+    if (updateToc)
+      {
+      if (auto dot = state->detection->type())
+        {
+        std::map<int, double> toc;
+        for (const auto& c : *dot)
+          {
+          toc.emplace(this->getTrackTypeIndex(c.first->c_str()), c.second);
+          }
+        track->SetTOC(toc);
+        }
+      }
     }
 #endif
 }
@@ -8615,7 +8646,7 @@ void vpViewCore::executeEmbeddedPipeline(
         vpTrackIO::GetDefaultTrackColor(nextId, color);
         newTrack->SetColor(color);
 
-        this->updateTrack(newTrack, kwiverTrack, timeMap, videoHeight);
+        this->updateTrack(newTrack, kwiverTrack, timeMap, videoHeight, true);
 
         trackModel->AddTrack(newTrack);
         newTrack->FastDelete();

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -8559,6 +8559,8 @@ void vpViewCore::executeEmbeddedPipeline(
 {
 #ifdef VISGUI_USE_KWIVER
   auto project = this->Projects[session];
+  const auto videoHeight =
+    static_cast<double>(project->ModelIO->GetImageHeight());
 
   // Ensure time map is complete
   if (this->UsingTimeStampData && !this->waitForFrameMapRebuild())
@@ -8574,7 +8576,7 @@ void vpViewCore::executeEmbeddedPipeline(
   // Set up worker
   vpKwiverEmbeddedPipelineWorker worker;
   if (!worker.initialize(pipelinePath, this->ImageDataSource,
-                         project->TrackModel))
+                         project->TrackModel, videoHeight))
     {
     return;
     }
@@ -8593,8 +8595,6 @@ void vpViewCore::executeEmbeddedPipeline(
   const auto& tracks = worker.tracks();
   if (tracks)
     {
-    const auto videoHeight =
-      static_cast<double>(project->ModelIO->GetImageHeight());
     const auto& timeMap = this->FrameMap->getTimeMap();
 
     auto trackModel = this->Projects[session]->TrackModel;

--- a/Applications/VpView/vpViewCore.h
+++ b/Applications/VpView/vpViewCore.h
@@ -7,22 +7,33 @@
 #ifndef __vpViewCore_h
 #define __vpViewCore_h
 
-#include <QObject>
-#include <QScopedPointer>
-#include <QSharedPointer>
-#include <QString>
-#include <QStringList>
+#include "vpTrackIO.h"
+
+#include <vtkVgTimeStamp.h>   // Required for vtkVgTimeStamp.
 
 #include <vgAttributeSet.h>
 #include <vgNamespace.h>
 
 #include <vtkSmartPointer.h>   // Required for smart pointer internal ivars.
 
-#include <vtkVgTimeStamp.h>   // Required for vtkVgTimeStamp.
+#include <QObject>
+#include <QScopedPointer>
+#include <QSharedPointer>
+#include <QString>
+#include <QStringList>
 
-#include "vpTrackIO.h"
+#include <map>
+#include <memory>
+#include <vector>
 
-// Forward VTK class declarations
+namespace kwiver
+{
+namespace vital
+{
+class track;
+}
+}
+
 class vtkActor;
 class vtkActor2D;
 class vtkCamera;
@@ -98,9 +109,6 @@ class vpTrackConfig;
 class vpVideoAnimation;
 
 class vtkVpTrackModel;
-
-// STL includes.
-#include <vector> // STL required.
 
 class vpViewCore : public QObject
 {
@@ -226,6 +234,10 @@ public:
 
   bool createTrack(int trackId, int session, bool isFse = false);
   int  createEvent(int type, vtkIdList* ids, int session);
+
+  void updateTrack(vtkVgTrack*, const std::shared_ptr<kwiver::vital::track>&,
+                   const std::map<unsigned int, vgTimeStamp>& timeMap,
+                   double videoHeight);
 
   void improveTrack(int trackId, int session);
   bool splitTrack(int trackId, int newTrackId, int session);

--- a/Applications/VpView/vpViewCore.h
+++ b/Applications/VpView/vpViewCore.h
@@ -387,6 +387,8 @@ public:
   void startExternalProcess();
   bool isExternalProcessRunning();
 
+  void executeEmbeddedPipeline(int session, const QString& pipelinePath);
+
   void toWindowCoordinates(double&x, double&y);
   void toWindowCoordinates(double (&xy)[2]);
 

--- a/Applications/VpView/vpViewCore.h
+++ b/Applications/VpView/vpViewCore.h
@@ -235,9 +235,11 @@ public:
   bool createTrack(int trackId, int session, bool isFse = false);
   int  createEvent(int type, vtkIdList* ids, int session);
 
+  int getTrackTypeIndex(const char* typeName);
+
   void updateTrack(vtkVgTrack*, const std::shared_ptr<kwiver::vital::track>&,
                    const std::map<unsigned int, vgTimeStamp>& timeMap,
-                   double videoHeight);
+                   double videoHeight, bool updateToc = false);
 
   void improveTrack(int trackId, int session);
   bool splitTrack(int trackId, int newTrackId, int session);

--- a/Libraries/VtkVgModelView/vtkVgTrackInfo.h
+++ b/Libraries/VtkVgModelView/vtkVgTrackInfo.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -28,6 +28,11 @@ public:
   explicit vtkVgTrackInfo(vtkVgTrack* track = 0)
     : TrackAndTraits(track, DisplayTrack | PassesFilters | HeadVisible)
     {}
+
+  operator bool() const
+    {
+    return !!this->TrackAndTraits.GetPointer();
+    }
 
   void SetTrack(vtkVgTrack* t)
     {


### PR DESCRIPTION
This adds the ability to run KWIVER pipelines from within WAMI viewer. Pipelines can consume imagery and can consume and/or produce tracks.