### PR TITLE
Clean up some WAMI Viewer image reading stuff

### DIFF
--- a/Applications/VpView/vpImageSourceFactory.h
+++ b/Applications/VpView/vpImageSourceFactory.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -9,38 +9,22 @@
 
 #include <vgAbstractFactory.h>
 
-// C++ includes
-#include <string>
-
 #include <vtkVgBaseImageSource.h>
+
+#include <string>
 
 //-----------------------------------------------------------------------------
 class vpImageSourceFactory : public vgAbstractFactory<vtkVgBaseImageSource*, std::string>
 {
 public:
-
   static vpImageSourceFactory*    GetInstance();
   static void                     OnApplicationExit();
 
   virtual vtkVgBaseImageSource*   Create(std::string source);
 
-
 private:
-
   static void CleanUp();
-
   static vpImageSourceFactory* Instance;
 };
 
-//-----------------------------------------------------------------------------
-struct RegisterVpImageSource
-{
-  typedef vtkVgBaseImageSource* (*Creator)();
-
-  RegisterVpImageSource(Creator function)
-    {
-    vpImageSourceFactory::GetInstance()->Register(function);
-    }
-};
-
-#endif // __vpImageSourceFactory_h
+#endif

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -1915,14 +1915,16 @@ void vpViewCore::initializeViewInteractions()
 //-----------------------------------------------------------------------------
 void vpViewCore::initializeSources()
 {
-  RegisterVpImageSource registerPNGImageSouce(&vtkVgPNGReader::Create);
-  RegisterVpImageSource registerMRJImageSouce(&vtkVgMultiResJpgImageReader2::Create);
-  RegisterVpImageSource registerJP2ImageSource(&vtkVgImageSource::Create);
-  RegisterVpImageSource registerJPEGImageSource(&vtkVgJPEGReader::Create);
-  RegisterVpImageSource registerSGIImageSouce(&vtkVgSGIReader::Create);
+  auto* const factory = vpImageSourceFactory::GetInstance();
+
+  factory->Register(&vtkVgPNGReader::Create);
+  factory->Register(&vtkVgMultiResJpgImageReader2::Create);
+  factory->Register(&vtkVgImageSource::Create);
+  factory->Register(&vtkVgJPEGReader::Create);
+  factory->Register(&vtkVgSGIReader::Create);
 
 #if defined(VISGUI_USE_GDAL)
-  RegisterVpImageSource registerGDALImageSource(&vtkVgGDALReader::Create);
+  factory->Register(&vtkVgGDALReader::Create);
 #endif
 }
 

--- a/Libraries/VtkVgCore/vtkVgBaseImageSource.cxx
+++ b/Libraries/VtkVgCore/vtkVgBaseImageSource.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -19,8 +19,6 @@ vtkVgBaseImageSource::vtkVgBaseImageSource() : vtkImageAlgorithm(),
 
   for (int i = 0; i < 4; ++i) {this->ReadExtents[i] = -1;}
   for (int i = 0; i < 3; ++i) {this->Origin[i] = 0; this->Spacing[i] = 1;}
-
-  this->ImageTimeStamp.Reset();
 
   this->SetNumberOfInputPorts(0);
 }

--- a/Libraries/VtkVgCore/vtkVgBaseImageSource.h
+++ b/Libraries/VtkVgCore/vtkVgBaseImageSource.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -100,7 +100,7 @@ public:
   // Get image timestamp
   virtual vtkVgTimeStamp GetImageTimeStamp()
     {
-    return this->ImageTimeStamp;
+    return {};
     }
 
   // Description:
@@ -164,8 +164,6 @@ protected:
   double  Spacing[3];
 
   char*   FileName;
-
-  vtkVgTimeStamp ImageTimeStamp;
 };
 
 #endif // __vtkVgBaseImageSource_h

--- a/Libraries/VtkVgCore/vtkVgBaseImageSource.h
+++ b/Libraries/VtkVgCore/vtkVgBaseImageSource.h
@@ -106,15 +106,15 @@ public:
   // Description:
   // Check if a given source (file, extension) can be read by
   // this source.
-  virtual bool CanRead(const std::string& source) = 0;
+  virtual bool CanRead(const std::string& source) const = 0;
 
   // Description:
   // Return a short description of the source (for display purposes).
-  virtual std::string GetShortDescription() = 0;
+  virtual std::string GetShortDescription() const = 0;
 
   // Description:
   // Return a long description of the source.
-  virtual std::string GetLongDescription() = 0;
+  virtual std::string GetLongDescription() const = 0;
 
   // Description:
   // FIXME

--- a/Libraries/VtkVgCore/vtkVgImageSource.cxx
+++ b/Libraries/VtkVgCore/vtkVgImageSource.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -400,7 +400,7 @@ const int* vtkVgImageSource::GetFullImageExtents()
 }
 
 //----------------------------------------------------------------------------
-bool vtkVgImageSource::CanRead(const std::string& source)
+bool vtkVgImageSource::CanRead(const std::string& source) const
 {
   std::string ciSource = vtksys::SystemTools::LowerCase(source);
 
@@ -416,13 +416,13 @@ bool vtkVgImageSource::CanRead(const std::string& source)
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgImageSource::GetShortDescription()
+std::string vtkVgImageSource::GetShortDescription() const
 {
   return "Reader for PNG file format";
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgImageSource::GetLongDescription()
+std::string vtkVgImageSource::GetLongDescription() const
 {
   return this->GetShortDescription();
 }

--- a/Libraries/VtkVgCore/vtkVgImageSource.h
+++ b/Libraries/VtkVgCore/vtkVgImageSource.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -27,11 +27,11 @@ public:
 
   const int* GetFullImageExtents();
 
-  virtual bool CanRead(const std::string& source);
+  virtual bool CanRead(const std::string& source) const;
 
-  virtual std::string GetShortDescription();
+  virtual std::string GetShortDescription() const;
 
-  virtual std::string GetLongDescription();
+  virtual std::string GetLongDescription() const;
 
   static vtkVgBaseImageSource* Create();
 

--- a/Libraries/VtkVgCore/vtkVgJPEGReader.cxx
+++ b/Libraries/VtkVgCore/vtkVgJPEGReader.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -66,7 +66,7 @@ void vtkVgJPEGReader::GetDimensions(int dim[2])
 }
 
 //----------------------------------------------------------------------------
-bool vtkVgJPEGReader::CanRead(const std::string& source)
+bool vtkVgJPEGReader::CanRead(const std::string& source) const
 {
   std::string ciSource = vtksys::SystemTools::LowerCase(source);
 
@@ -85,13 +85,13 @@ bool vtkVgJPEGReader::CanRead(const std::string& source)
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgJPEGReader::GetShortDescription()
+std::string vtkVgJPEGReader::GetShortDescription() const
 {
   return "Reader for JPEG file format";
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgJPEGReader::GetLongDescription()
+std::string vtkVgJPEGReader::GetLongDescription() const
 {
   return this->GetShortDescription();
 }

--- a/Libraries/VtkVgCore/vtkVgJPEGReader.h
+++ b/Libraries/VtkVgCore/vtkVgJPEGReader.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -40,15 +40,15 @@ public:
 
   // Description:
   // Check if the reader can read a given source.
-  virtual bool CanRead(const std::string& source);
+  virtual bool CanRead(const std::string& source) const;
 
   // Description:
   // Return short description of reader
-  virtual std::string GetShortDescription();
+  virtual std::string GetShortDescription() const;
 
   // Description:
   // Return long description of reader
-  virtual std::string GetLongDescription();
+  virtual std::string GetLongDescription() const;
 
   // Description:
   // Create instance of reader

--- a/Libraries/VtkVgCore/vtkVgMultiResJpgImageReader2.cxx
+++ b/Libraries/VtkVgCore/vtkVgMultiResJpgImageReader2.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -94,7 +94,7 @@ int vtkVgMultiResJpgImageReader2::GetNumberOfLevels() const
 }
 
 //----------------------------------------------------------------------------
-bool vtkVgMultiResJpgImageReader2::CanRead(const std::string& source)
+bool vtkVgMultiResJpgImageReader2::CanRead(const std::string& source) const
 {
   std::string ciSource = vtksys::SystemTools::LowerCase(source);
 
@@ -110,13 +110,13 @@ bool vtkVgMultiResJpgImageReader2::CanRead(const std::string& source)
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgMultiResJpgImageReader2::GetShortDescription()
+std::string vtkVgMultiResJpgImageReader2::GetShortDescription() const
 {
   return "Reader for MRJ file format";
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgMultiResJpgImageReader2::GetLongDescription()
+std::string vtkVgMultiResJpgImageReader2::GetLongDescription() const
 {
   return this->GetShortDescription();
 }

--- a/Libraries/VtkVgCore/vtkVgMultiResJpgImageReader2.h
+++ b/Libraries/VtkVgCore/vtkVgMultiResJpgImageReader2.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -78,11 +78,11 @@ public:
   // Return the number of level of details.
   virtual int GetNumberOfLevels() const;
 
-  virtual bool CanRead(const std::string& source);
+  virtual bool CanRead(const std::string& source) const;
 
-  virtual std::string GetShortDescription();
+  virtual std::string GetShortDescription() const;
 
-  virtual std::string GetLongDescription();
+  virtual std::string GetLongDescription() const;
 
   static vtkVgBaseImageSource* Create();
 

--- a/Libraries/VtkVgCore/vtkVgPNGReader.cxx
+++ b/Libraries/VtkVgCore/vtkVgPNGReader.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -66,7 +66,7 @@ void vtkVgPNGReader::GetDimensions(int dim[2])
 }
 
 //----------------------------------------------------------------------------
-bool vtkVgPNGReader::CanRead(const std::string& source)
+bool vtkVgPNGReader::CanRead(const std::string& source) const
 {
   std::string ciSource = vtksys::SystemTools::LowerCase(source);
 
@@ -82,13 +82,13 @@ bool vtkVgPNGReader::CanRead(const std::string& source)
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgPNGReader::GetShortDescription()
+std::string vtkVgPNGReader::GetShortDescription() const
 {
   return "Reader for PNG file format";
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgPNGReader::GetLongDescription()
+std::string vtkVgPNGReader::GetLongDescription() const
 {
   return this->GetShortDescription();
 }

--- a/Libraries/VtkVgCore/vtkVgPNGReader.h
+++ b/Libraries/VtkVgCore/vtkVgPNGReader.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -38,11 +38,11 @@ public:
   // Return dimensions of the image.
   virtual void GetDimensions(int dim[2]);
 
-  virtual bool CanRead(const std::string& source);
+  virtual bool CanRead(const std::string& source) const;
 
-  virtual std::string GetShortDescription();
+  virtual std::string GetShortDescription() const;
 
-  virtual std::string GetLongDescription();
+  virtual std::string GetLongDescription() const;
 
   static vtkVgBaseImageSource* Create();
 

--- a/Libraries/VtkVgCore/vtkVgSGIReader.cxx
+++ b/Libraries/VtkVgCore/vtkVgSGIReader.cxx
@@ -128,7 +128,7 @@ void vtkVgSGIReader::GetDimensions(int dim[2])
 }
 
 //----------------------------------------------------------------------------
-bool vtkVgSGIReader::CanRead(const std::string& source)
+bool vtkVgSGIReader::CanRead(const std::string& source) const
 {
   std::string ciSource = vtksys::SystemTools::LowerCase(source);
 
@@ -143,13 +143,13 @@ bool vtkVgSGIReader::CanRead(const std::string& source)
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgSGIReader::GetShortDescription()
+std::string vtkVgSGIReader::GetShortDescription() const
 {
   return "Reader for SGI file format";
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgSGIReader::GetLongDescription()
+std::string vtkVgSGIReader::GetLongDescription() const
 {
   return this->GetShortDescription();
 }

--- a/Libraries/VtkVgCore/vtkVgSGIReader.h
+++ b/Libraries/VtkVgCore/vtkVgSGIReader.h
@@ -37,11 +37,11 @@ public:
   // Return dimensions of the image.
   virtual void GetDimensions(int dim[2]) override;
 
-  virtual bool CanRead(const std::string& source) override;
+  virtual bool CanRead(const std::string& source) const override;
 
-  virtual std::string GetShortDescription() override;
+  virtual std::string GetShortDescription() const override;
 
-  virtual std::string GetLongDescription() override;
+  virtual std::string GetLongDescription() const override;
 
   static vtkVgBaseImageSource* Create();
 

--- a/Libraries/VtkVgIO/vtkVgGDALReader.cxx
+++ b/Libraries/VtkVgIO/vtkVgGDALReader.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -103,7 +103,7 @@ vtkVgTimeStamp vtkVgGDALReader::GetImageTimeStamp()
 }
 
 //----------------------------------------------------------------------------
-bool vtkVgGDALReader::CanRead(const std::string& source)
+bool vtkVgGDALReader::CanRead(const std::string& source) const
 {
   std::string ciSource = vtksys::SystemTools::LowerCase(source);
 
@@ -127,13 +127,13 @@ bool vtkVgGDALReader::CanRead(const std::string& source)
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgGDALReader::GetShortDescription()
+std::string vtkVgGDALReader::GetShortDescription() const
 {
   return "Generic image reader implemented using GDAL library";
 }
 
 //----------------------------------------------------------------------------
-std::string vtkVgGDALReader::GetLongDescription()
+std::string vtkVgGDALReader::GetLongDescription() const
 {
   return this->GetShortDescription();
 }

--- a/Libraries/VtkVgIO/vtkVgGDALReader.h
+++ b/Libraries/VtkVgIO/vtkVgGDALReader.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -81,6 +81,8 @@ protected:
   vtkImageData* ImageCache;
 
   vtkGDALReader* Reader;
+
+  vtkVgTimeStamp ImageTimeStamp;
 
 private:
 

--- a/Libraries/VtkVgIO/vtkVgGDALReader.h
+++ b/Libraries/VtkVgIO/vtkVgGDALReader.h
@@ -54,10 +54,10 @@ public:
   // Get image timestamp
   virtual vtkVgTimeStamp GetImageTimeStamp();
 
-  virtual bool CanRead(const std::string& source);
+  virtual bool CanRead(const std::string& source) const;
 
-  virtual std::string GetShortDescription();
-  virtual std::string GetLongDescription();
+  virtual std::string GetShortDescription() const;
+  virtual std::string GetLongDescription() const;
 
   virtual vtkSmartPointer<vtkMatrix4x4> GetImageToWorldMatrix();
 


### PR DESCRIPTION
Get rid of superfluous `RegisterVpImageSource` "helper" class. Add `const` to some methods of `vtkVgBaseImageSource` that really have no excuse for *not* being `const`. Don't store time stamp in `vtkVgBaseImageSource`.