### PR TITLE
Refactor WAMI Viewer frame source classes

### DIFF
--- a/Applications/VpView/vpFileDataSource.cxx
+++ b/Applications/VpView/vpFileDataSource.cxx
@@ -1,35 +1,60 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
 #include "vpFileDataSource.h"
 
-#include <vtksys/Glob.hxx>
-#include <vtksys/SystemTools.hxx>
+#include <qtNaturalSort.h>
 
-// C++ includes.
-#include <iostream>
-#include <fstream>
-
-// VTK includes.
-#include <vtkNew.h>
-#include <vtkSortFileNames.h>
-#include <vtkStringArray.h>
-
-// Qt includes.
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QFileSystemWatcher>
-#include <QMutexLocker>
 #include <QStringList>
 
-#include <qtStlUtil.h>
+#include <algorithm>
+
+namespace // anonymous
+{
 
 //-----------------------------------------------------------------------------
-vpFileDataSource::vpFileDataSource() :
-  MonitoringEnabled(false), DataFilesMutex(QMutex::Recursive)
+QStringList glob(const QDir& base, const QString& pattern)
 {
-  this->DataFiles = vtkSmartPointer<vtkStringArray>::New();
+  QStringList matches;
+
+  // TODO handle multi-level globs
+  foreach (const auto& p, base.entryList(QDir::Files))
+  {
+    if (QDir::match(pattern, p))
+    {
+      matches.append(base.filePath(p));
+    }
+  }
+
+  return matches;
+}
+
+} // namespace <anonymous>
+
+//-----------------------------------------------------------------------------
+class vpFileDataSourcePrivate
+{
+public:
+  QString DataSetSpecifier;
+  QStringList DataFiles;
+
+  bool MonitoringEnabled = false;
+  QScopedPointer<QFileSystemWatcher> DataFilesWatcher;
+};
+
+QTE_IMPLEMENT_D_FUNC(vpFileDataSource)
+
+//-----------------------------------------------------------------------------
+vpFileDataSource::vpFileDataSource() : d_ptr{new vpFileDataSourcePrivate}
+{
 }
 
 //-----------------------------------------------------------------------------
@@ -38,213 +63,172 @@ vpFileDataSource::~vpFileDataSource()
 }
 
 //-----------------------------------------------------------------------------
-void vpFileDataSource::setDataSetSpecifier(const std::string& source)
+void vpFileDataSource::setDataSetSpecifier(const QString& source)
 {
-  this->DataSetSpecifier = source;
-  this->ModifiedTime.Modified();
-}
+  QTE_D();
 
-//-----------------------------------------------------------------------------
-std::string vpFileDataSource::getDataSetSpecifier()
-{
-  return this->DataSetSpecifier;
-}
-
-//-----------------------------------------------------------------------------
-void vpFileDataSource::setDataFiles(const std::vector<std::string>& filenames)
-{
-  this->clear();
-  this->DataSetSpecifier.clear();
-
-  for (size_t i = 0, size = filenames.size(); i < size; ++i)
-    {
-    this->DataFiles->InsertNextValue(filenames[i]);
-    }
-}
-
-//-----------------------------------------------------------------------------
-int vpFileDataSource::getFileCount()
-{
-  QMutexLocker ml(&this->DataFilesMutex);
+  d->DataSetSpecifier = source;
+  d->DataFilesWatcher.reset();
   this->update();
-  return static_cast<int>(this->DataFiles->GetNumberOfValues());
 }
 
 //-----------------------------------------------------------------------------
-std::string vpFileDataSource::getDataFile(int index)
+QString vpFileDataSource::dataSetSpecifier() const
 {
-  QMutexLocker ml(&this->DataFilesMutex);
-  this->update();
+  QTE_D();
+  return d->DataSetSpecifier;
+}
 
-  if (index < 0 || index >= this->DataFiles->GetNumberOfValues())
-    {
-    return std::string();
-    }
+//-----------------------------------------------------------------------------
+void vpFileDataSource::setDataFiles(const QStringList& filenames)
+{
+  QTE_D();
 
-  return this->DataFiles->GetValue(index);
+  d->DataSetSpecifier.clear();
+  d->DataFiles = filenames;
+
+  d->MonitoringEnabled = false;
+  d->DataFilesWatcher.reset();
+}
+
+//-----------------------------------------------------------------------------
+int vpFileDataSource::frames() const
+{
+  QTE_D();
+  return d->DataFiles.count();
+}
+
+//-----------------------------------------------------------------------------
+QString vpFileDataSource::frameName(int index) const
+{
+  QTE_D();
+  return d->DataFiles.value(index);
+}
+
+//-----------------------------------------------------------------------------
+QStringList vpFileDataSource::frameNames() const
+{
+  QTE_D();
+  return d->DataFiles;
 }
 
 //-----------------------------------------------------------------------------
 void vpFileDataSource::setMonitoringEnabled(bool enable)
 {
-  QMutexLocker ml(&this->DataFilesMutex);
-  this->ModifiedTime.Modified();
-  this->MonitoringEnabled = enable;
-  if (!enable)
-    {
-    this->DataFilesWatcher.reset();
-    }
-  else
-    {
+  QTE_D();
+
+  d->MonitoringEnabled = enable;
+  if (enable)
+  {
     this->update();
-    }
+  }
+  else
+  {
+    d->DataFilesWatcher.reset();
+  }
 }
 
 //-----------------------------------------------------------------------------
 void vpFileDataSource::update()
 {
-  QMutexLocker ml(&this->DataFilesMutex);
-  if (this->UpdateTime > this->ModifiedTime)
-    {
+  QTE_D();
+
+  if (d->DataSetSpecifier.isEmpty())
+  {
     return;
-    }
+  }
 
-  this->UpdateTime.Modified();
+  d->DataFiles.clear();
 
-  if (this->DataSetSpecifier.empty())
+  QString watchPath;
+  QFileInfo fi{d->DataSetSpecifier};
+
+  if (fi.exists())
+  {
+    watchPath = fi.absoluteFilePath();
+
+    const auto baseDir = fi.absoluteDir();
+
+    QFile file{d->DataSetSpecifier};
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text))
     {
-    return;
-    }
-
-  // First clear any data structure before we read new data source.
-  this->clear();
-
-  std::string line;
-  std::string watchPath;
-
-  if (vtksys::SystemTools::FileExists(this->DataSetSpecifier.c_str(), true))
-    {
-    std::string basePath =
-      vtksys::SystemTools::GetFilenamePath(this->DataSetSpecifier.c_str());
-    basePath.append("/");
-
-    std::string completePath;
-    watchPath = this->DataSetSpecifier;
-
-    std::ifstream file(this->DataSetSpecifier.c_str());
-
-    if (file.is_open())
+      while (!file.atEnd())
       {
-      while (!file.eof() || file.good())
+        const auto line = file.readLine();
+        if (line.isEmpty())
         {
-        std::getline(file, line);
-
-        if (line.empty())
-          {
           continue;
-          }
-
-        // If each line is not a full path then append the base path or
-        // if the file is not found try finding the file using base path.
-        if (!vtksys::SystemTools::FileIsFullPath(line.c_str()) ||
-            !vtksys::SystemTools::FileExists(line.c_str(), true))
-          {
-          completePath = basePath + line;
-          }
-        else
-          {
-          completePath = line;
-          }
-
-        if (!vtksys::SystemTools::FileExists(completePath.c_str(), true))
-          {
-          std::cerr << "Image data file (" << completePath
-                    << ") does not exist. " << std::endl;
-          continue;
-          }
-
-        std::cerr << "Archiving (" << completePath << "). " << std::endl;
-
-        this->DataFiles->InsertNextValue(completePath);
         }
+
+        const auto path = baseDir.absoluteFilePath(QString::fromUtf8(line));
+        if (!QFileInfo{path}.exists())
+        {
+          qWarning() << "Image data file" << path << "does not exist";
+          continue;
+        }
+
+        qDebug() << "Archiving" << path;
+        d->DataFiles.append(path);
       }
+    }
     else
-      {
-      std::cerr << "Unable to open this  (" << this->DataSetSpecifier
-                << ") data source. " << std::endl;
-      return;
-      }
-    }
-  else
     {
-    // Interpret the specifier as a glob
-    vtksys::Glob glob;
-    glob.FindFiles(this->DataSetSpecifier);
-    glob.SetRecurse(true);
-    std::vector<std::string>& files = glob.GetFiles();
-    if (files.empty())
-      {
+      qWarning().nospace()
+        << "Unable to open data source " << d->DataSetSpecifier
+        << ": " << file.errorString();
       return;
-      }
-
-    int numFiles = static_cast<int>(files.size());
-    vtkNew<vtkStringArray> fileNames;
-    fileNames->SetNumberOfValues(numFiles);
-    for (int i = 0; i < numFiles; i++)
-      {
-      fileNames->SetValue(i, files[i].c_str());
-      }
-
-    vtkNew<vtkSortFileNames> sort;
-    sort->NumericSortOn();
-    sort->SetInputFileNames(fileNames.GetPointer());
-    this->DataFiles = sort->GetFileNames();
-
-    watchPath =
-     vtksys::SystemTools::GetFilenamePath(this->DataFiles->GetValue(0));
     }
+  }
+  else
+  {
+    const auto& dir = fi.absoluteDir();
+    const auto& pattern = fi.fileName();
+
+    // auto files = glob(QDir::current(), d->DataSetSpecifier); TODO
+    auto files = glob(dir, pattern);
+    std::sort(files.begin(), files.end(), qtNaturalSort::compare{});
+
+    d->DataFiles = files;
+    watchPath = dir.absolutePath();
+    // TODO get watch paths for multi-level glob
+  }
 
   // Begin monitoring the parent directory or the text file containing the
   // image filenames for changes. When a change is detected, we will update
   // ourselves automatically.
-  if (this->MonitoringEnabled &&
-      !this->DataFilesWatcher && !watchPath.empty())
-    {
-    std::cout << "Starting image data monitoring.\n";
-    this->DataFilesWatcher.reset(new QFileSystemWatcher);
+  if (d->MonitoringEnabled && !d->DataFilesWatcher && !watchPath.isEmpty())
+  {
+    // TODO handle multiple watch paths and the potential need to add paths
+    // if new directories match a multi-level glob
+    qDebug() << "Starting image data monitoring for path" << watchPath;
+    d->DataFilesWatcher.reset(new QFileSystemWatcher);
 
     // Force watcher to use polling since the normal engine doesn't work
-    // with network shares.
-    this->DataFilesWatcher->setObjectName(
+    // with network shares. See https://bugreports.qt.io/browse/QTBUG-8351.
+    d->DataFilesWatcher->setObjectName(
       QLatin1String("_qt_autotest_force_engine_poller"));
 
-    connect(this->DataFilesWatcher.data(),
-            SIGNAL(directoryChanged(QString)),
+    connect(d->DataFilesWatcher.data(), SIGNAL(directoryChanged(QString)),
             this, SLOT(updateDataFiles()));
 
-    connect(this->DataFilesWatcher.data(),
-            SIGNAL(fileChanged(QString)),
+    connect(d->DataFilesWatcher.data(), SIGNAL(fileChanged(QString)),
             this, SLOT(updateDataFiles()));
 
-    this->DataFilesWatcher->addPath(qtString(watchPath));
-    std::cout << "Image data monitoring started.\n";
-    }
-}
-
-//-----------------------------------------------------------------------------
-void vpFileDataSource::clear()
-{
-  QMutexLocker ml(&this->DataFilesMutex);
-  this->DataFiles->Reset();
+    d->DataFilesWatcher->addPath(watchPath);
+    qDebug() << "Image data monitoring started";
+  }
 }
 
 //-----------------------------------------------------------------------------
 void vpFileDataSource::updateDataFiles()
 {
-    {
-    QMutexLocker ml(&this->DataFilesMutex);
-    this->ModifiedTime.Modified();
-    this->update();
-    }
-  emit this->dataFilesChanged();
+  QTE_D();
+
+  auto oldDataFiles = d->DataFiles;
+  this->update();
+
+  if (d->DataFiles != oldDataFiles)
+  {
+    emit this->frameSetChanged();
+  }
 }

--- a/Applications/VpView/vpFileDataSource.h
+++ b/Applications/VpView/vpFileDataSource.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -7,72 +7,44 @@
 #ifndef __vpFileDataSource_h
 #define __vpFileDataSource_h
 
-// C++ STL includes.
-#include <string>
-#include <vector>
+#include <qtGlobal.h>
 
-#include <QMutex>
 #include <QObject>
-#include <QScopedPointer>
 
-#include <vtkSmartPointer.h>
-#include <vtkTimeStamp.h>
-
-// Forward declarations.
-class QFileSystemWatcher;
-
-class vtkStringArray;
+class vpFileDataSourcePrivate;
 
 class vpFileDataSource : public QObject
 {
   Q_OBJECT
 
 public:
-  // Description:
-  // Constructor / destructor
   vpFileDataSource();
   ~vpFileDataSource();
 
-  // Description:
-  // Set the data source. Currently it takes the filename
-  // or the Glob.
-  void setDataSetSpecifier(const std::string& source);
-  std::string getDataSetSpecifier();
+  void setDataSetSpecifier(const QString& source);
+  QString dataSetSpecifier() const;
 
-  // Description:
-  // Set the data set directly from an ordered vector of filenames
-  void setDataFiles(const std::vector<std::string>& filenames);
+  void setDataFiles(const QStringList& filenames);
 
-  int getFileCount();
+  int frames() const;
+  QString frameName(int index) const;
+  QStringList frameNames() const;
 
-  // Description:
-  // Return a specific file using the index [0, size - 1]
-  std::string getDataFile(int index);
-
-  // Description:
-  // Enable monitoring for data set changes
-  void setMonitoringEnabled(bool enable);
+  void setMonitoringEnabled(bool);
 
 signals:
-  void dataFilesChanged();
+  void frameSetChanged();
 
 protected:
+  QTE_DECLARE_PRIVATE_RPTR(vpFileDataSource)
+
   void update();
-  void clear();
 
 protected slots:
   void updateDataFiles();
 
 private:
-  std::string DataSetSpecifier;
-  vtkSmartPointer<vtkStringArray> DataFiles;
-
-  vtkTimeStamp ModifiedTime;
-  vtkTimeStamp UpdateTime;
-
-  bool MonitoringEnabled;
-  QScopedPointer<QFileSystemWatcher> DataFilesWatcher;
-  QMutex DataFilesMutex;
+  QTE_DECLARE_PRIVATE(vpFileDataSource)
 };
 
-#endif // __vpFileDataSource_h
+#endif

--- a/Applications/VpView/vpFrameMap.h
+++ b/Applications/VpView/vpFrameMap.h
@@ -17,10 +17,11 @@
 
 #include <QThread>
 
-#include <map>
-#include <vector>
-
 // Forward declarations.
+template <typename T> class QList;
+template <typename T1, typename T2> struct QPair;
+template <typename K, typename V> class QMap;
+
 class vtkMatrix4x4;
 
 class vpFileDataSource;
@@ -29,8 +30,7 @@ class vpFrameMapPrivate;
 class vpFrame
 {
 public:
-  vpFrame() : Index(0), Homography(0)
-    {}
+  vpFrame() = default;
 
   ~vpFrame()
     {
@@ -40,12 +40,12 @@ public:
       }
     }
 
-  void set(unsigned int index, vgTimeStamp time,
-           const vtkMatrix4x4* homography = 0);
+  void set(int index, vgTimeStamp time,
+           const vtkMatrix4x4* homography = nullptr);
 
-  unsigned int Index;
+  int Index = 0;
   vtkVgTimeStamp Time;
-  vtkMatrix4x4* Homography;
+  vtkMatrix4x4* Homography = nullptr;
 };
 
 class vpFrameMap : public QThread
@@ -63,20 +63,18 @@ public:
 
   bool first(vpFrame& frame);
   bool last(vpFrame& frame);
-  bool getFrame(unsigned int frameIndex, vpFrame& frameValue);
+  bool getFrame(int frameIndex, vpFrame& frameValue);
 
-  std::map<unsigned int, vgTimeStamp> getTimeMap();
+  QMap<int, vgTimeStamp> timeMap();
 
-  void setImageTime(const std::string& filename, double microseconds);
-  void setImageHomography(const std::string& filename,
-                          vtkMatrix4x4 *homography);
+  void setImageTime(const QString& filename, double microseconds);
+  void setImageHomography(const QString& filename, vtkMatrix4x4* homography);
   void startUpdate();
   void stop();
 
   int progress();
 
-  void exportImageTimes(std::vector<std::pair<std::string, double> >&
-                          imageTimes);
+  QList<QPair<QString, double>> imageTimes();
 
 signals:
   void updated();

--- a/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
+++ b/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
@@ -106,7 +106,7 @@ public:
 
   void reportProgress(int);
 
-  std::vector<std::string> framePaths;
+  QStringList framePaths;
 
   kwiver::arrows::vxl::image_io loader;
   kwiver::embedded_pipeline pipeline;
@@ -137,8 +137,8 @@ void vpKwiverEmbeddedPipelineWorkerPrivate::run()
 {
   QTE_Q();
 
-  const auto totalFrames = this->framePaths.size();
-  emit q->progressRangeChanged(0, static_cast<int>(totalFrames));
+  const auto totalFrames = this->framePaths.count();
+  emit q->progressRangeChanged(0, totalFrames);
   emit q->progressValueChanged(0);
 
   const auto ports = this->pipeline.input_port_names();
@@ -164,7 +164,7 @@ void vpKwiverEmbeddedPipelineWorkerPrivate::run()
     if (image_port)
     {
       auto frameImage = this->loader.load(
-        this->framePaths[currentFrame]);
+        stdString(this->framePaths[currentFrame]));
 
       ids->add_value(*image_port, frameImage);
     }
@@ -251,10 +251,7 @@ bool vpKwiverEmbeddedPipelineWorker::initialize(
   QTE_D();
 
   // Copy inputs
-  for (const auto i : qtIndexRange(dataSource->getFileCount()))
-  {
-    d->framePaths.push_back(dataSource->getDataFile(i));
-  }
+  d->framePaths = dataSource->frameNames();
 
   trackModel->InitTrackTraversal();
   while (const auto& track = trackModel->GetNextTrack())

--- a/Applications/VpView/vpKwiverVideoSource.cxx
+++ b/Applications/VpView/vpKwiverVideoSource.cxx
@@ -8,16 +8,19 @@
 
 #include "vpFileDataSource.h"
 
+#include <qtStlUtil.h>
+
+#include <QStringList>
+
 namespace kv = kwiver::vital;
 
 //-----------------------------------------------------------------------------
 vpKwiverVideoSource::vpKwiverVideoSource(vpFileDataSource* ds) :
   CurrentFrame(-1)
 {
-  const auto totalFrames = ds->getFileCount();
-  for (int i = 0; i < totalFrames; ++i)
+  for (const auto& f : ds->frameNames())
     {
-    this->FramePaths.push_back(ds->getDataFile(i));
+    this->FramePaths.push_back(stdString(f));
     }
 }
 

--- a/Applications/VpView/vpQtViewer3d.cxx
+++ b/Applications/VpView/vpQtViewer3d.cxx
@@ -727,13 +727,13 @@ void vpQtViewer3d::updateContext(const vtkVgTimeStamp& timestamp)
     return;
     }
 
-  std::string nextDataFile =
-    this->ContextDataSource->getDataFile(timestamp.GetFrameNumber());
+  const auto frame = static_cast<int>(timestamp.GetFrameNumber());
+  const auto& nextDataFile = this->ContextDataSource->frameName(frame);
 
   if (!this->Internal->ContextSource)
     {
     this->Internal->ContextSource.TakeReference(
-      vpImageSourceFactory::GetInstance()->Create(nextDataFile));
+      vpImageSourceFactory::GetInstance()->Create(stdString(nextDataFile)));
     this->Internal->ContextSource->SetOrigin(this->Project->OverviewOrigin.x(),
                                              this->Project->OverviewOrigin.y(),
                                              0.0);
@@ -745,8 +745,7 @@ void vpQtViewer3d::updateContext(const vtkVgTimeStamp& timestamp)
       }
     }
 
-  this->Internal->ContextSource->SetFileName(
-    this->ContextDataSource->getDataFile(timestamp.GetFrameNumber()).c_str());
+  this->Internal->ContextSource->SetFileName(qPrintable(nextDataFile));
 
   double bounds[6];
   this->Internal->ContextPlaneActor->GetBounds(bounds);

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -328,7 +328,7 @@ void vpViewCore::newProject()
 
   if (!this->Projects.empty())
     {
-    editor.setDataset(qtString(this->ImageDataSource->getDataSetSpecifier()));
+    editor.setDataset(this->ImageDataSource->dataSetSpecifier());
     }
 
   if (editor.exec() == QDialog::Accepted)
@@ -444,7 +444,7 @@ void vpViewCore::importProject()
       }
     }
 
-  if (QDir::cleanPath(qtString(this->ImageDataSource->getDataSetSpecifier())) !=
+  if (QDir::cleanPath(this->ImageDataSource->dataSetSpecifier()) !=
       QDir::cleanPath(project->DataSetSpecifier))
     {
     if (QMessageBox::warning(0, QString(),
@@ -1599,8 +1599,8 @@ void vpViewCore::initializeAllOthers()
   this->ImageDataSource             = new vpFileDataSource();
   this->FrameMap                    = new vpFrameMap(this->ImageDataSource);
 
-  connect(this->ImageDataSource, SIGNAL(dataFilesChanged()), this,
-          SLOT(reactToDataChanged()));
+  connect(this->ImageDataSource, SIGNAL(frameSetChanged()),
+          this, SLOT(reactToDataChanged()));
 
   this->ProjectParser               = new vpProjectParser();
 
@@ -3123,10 +3123,15 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
     if (hasFrameMap)
       {
       // Use the image filenames retrieved as the dataset
-      this->ImageDataSource->setDataFiles(project->ModelIO->GetImageFiles());
+      QStringList frames;
+      foreach (const auto& f, project->ModelIO->GetImageFiles())
+        {
+        frames.append(qtString(f));
+        }
+      this->ImageDataSource->setDataFiles(frames);
 
       this->NumberOfFrames =
-        static_cast<unsigned int>(this->ImageDataSource->getFileCount());
+        static_cast<unsigned int>(this->ImageDataSource->frames());
 
       // If the expected metadata is not there, fall back to determining the
       // dataset from the project parameters.
@@ -3138,7 +3143,7 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
       else
         {
         if (project->ModelIO->GetHomographyCount() <
-            this->ImageDataSource->getFileCount())
+            this->ImageDataSource->frames())
           {
           emitHomographyCountWarning();
           }
@@ -3149,11 +3154,10 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
 
     if (!hasFrameMap)
       {
-      this->ImageDataSource->setDataSetSpecifier(
-        stdString(project->DataSetSpecifier));
+      this->ImageDataSource->setDataSetSpecifier(project->DataSetSpecifier);
 
       this->NumberOfFrames =
-        static_cast<unsigned int>(this->ImageDataSource->getFileCount());
+        static_cast<unsigned int>(this->ImageDataSource->frames());
 
       if (this->NumberOfFrames == 0)
         {
@@ -3208,12 +3212,12 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
             break;
             }
 
+          const auto frameCount = this->ImageDataSource->frames();
           int homographyCount = 0;
           bool endOfFile = false;
           int frameIndex;
           double timeStamp, matrixElement;
-          vtkSmartPointer<vtkMatrix4x4> homography =
-            vtkSmartPointer<vtkMatrix4x4>::New();
+          vtkNew<vtkMatrix4x4> homography;
           while (file >> frameIndex >> timeStamp)
             {
             for (int i = 0; i < 3 && !endOfFile; ++i)
@@ -3230,17 +3234,17 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
                                        matrixElement);
                 }
               }
-            // trusting that a negative frameIndex won't occur?
-            if (frameIndex >= this->ImageDataSource->getFileCount())
+            if (frameIndex < 0 || frameIndex >= frameCount)
               {
               break;
               }
 
-            this->FrameMap->setImageHomography(
-              this->ImageDataSource->getDataFile(frameIndex), homography);
+            const auto& frameName =
+              stdString(this->ImageDataSource->frameName(frameIndex));
+            this->FrameMap->setImageHomography(frameName, homography.Get());
             ++homographyCount;
             }
-          if (homographyCount < this->ImageDataSource->getFileCount())
+          if (homographyCount < frameCount)
             {
             emitHomographyCountWarning();
             }
@@ -3279,9 +3283,9 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
     this->ImageSource->SetOrigin(project->OverviewOrigin.x(),
                                  project->OverviewOrigin.y(), 0.0);
 
+    const auto frame = static_cast<int>(this->CoreTimeStamp.GetFrameNumber());
     this->ImageSource->SetFileName(
-      this->ImageDataSource->getDataFile(
-        this->CoreTimeStamp.GetFrameNumber()).c_str());
+      qPrintable(this->ImageDataSource->frameName(frame)));
 
     this->ImageSource->SetLevel(3);
     this->ImageSource->SetReadExtents(-1, -1, -1, -1);
@@ -3480,8 +3484,7 @@ vpProject* vpViewCore::processProject(QScopedPointer<vpProject>& project)
     }
   else
     {
-    const auto& dataSet =
-      qtString(this->ImageDataSource->getDataSetSpecifier());
+    const auto& dataSet = this->ImageDataSource->dataSetSpecifier();
     if (QDir::cleanPath(dataSet) != QDir::cleanPath(project->DataSetSpecifier))
       {
       QString str = "Warning: \"%1\" has a dataset specifier that doesn't match"
@@ -4166,11 +4169,11 @@ void vpViewCore::exportForWeb(const char* path, int paddingFrames)
   this->ImageSource->SetLevel(currentLevel);
   this->ImageSource->SetReadExtents(currentExtents);
 
-  std::string fileName = this->ImageDataSource->getDataFile(0);
+  const auto& firstFileName = this->ImageDataSource->frameName(0);
 
   vtkSmartPointer<vtkVgBaseImageSource> imageSource;
   imageSource.TakeReference(
-    vpImageSourceFactory::GetInstance()->Create(fileName));
+    vpImageSourceFactory::GetInstance()->Create(stdString(firstFileName)));
 
   if (!imageSource)
     {
@@ -4347,14 +4350,13 @@ void vpViewCore::exportForWeb(const char* path, int paddingFrames)
         id = newId;
         }
 
-      std::string fileName =
-        this->ImageDataSource->getDataFile(timeStamp.GetFrameNumber() -
-                                           this->FrameNumberOffset);
-      if (fileName.empty())
+      const auto frameNum =
+        static_cast<int>(timeStamp.GetFrameNumber() - this->FrameNumberOffset);
+      const auto& fileName =
+        this->ImageDataSource->frameName(frameNum);
+      if (fileName.isEmpty())
         {
-        qDebug() << "Image for frame"
-                 << timeStamp.GetFrameNumber() - this->FrameNumberOffset
-                 << "not found, skipping";
+        qDebug() << "Image for frame" << frameNum << "not found, skipping";
         continue;
         }
 
@@ -4390,7 +4392,7 @@ again:
       extents[3] = extents[2] + dim[1] - 1;
       extents[4] = extents[5] = 0;
 
-      imageSource->SetFileName(fileName.c_str());
+      imageSource->SetFileName(qPrintable(fileName));
       imageSource->UpdateInformation();
 
       int imageDimensions[2];
@@ -4594,7 +4596,7 @@ void vpViewCore::forceRender()
 void vpViewCore::reactToDataChanged()
 {
   this->NumberOfFrames =
-    static_cast<unsigned int>(this->ImageDataSource->getFileCount());
+    static_cast<unsigned int>(this->ImageDataSource->frames());
 
   if (this->UsingTimeStampData)
     {
@@ -5241,16 +5243,16 @@ void vpViewCore::forceUpdate()
   // Update the image data if the timestamp differs from last update
   if (this->ForceFullUpdate || this->CurrentFrame != this->LastFrame)
     {
-    std::string imageFile =
-      this->ImageDataSource->getDataFile(this->CurrentFrame);
-    if (imageFile.empty())
+    const auto& imageFile =
+      this->ImageDataSource->frameName(static_cast<int>(this->CurrentFrame));
+    if (imageFile.isEmpty())
       {
       return;
       }
 
     this->ForceFullUpdate = false;
     this->LastFrame = this->CurrentFrame;
-    this->ImageSource->SetFileName(imageFile.c_str());
+    this->ImageSource->SetFileName(qPrintable(imageFile));
 
     if (this->UseGeoCoordinates || this->UseRawImageCoordinates)
       {
@@ -6031,13 +6033,14 @@ void vpViewCore::initializeImageSource()
 {
   // Check here the extension of the files.
   // Grab the first file.
-  std::string fileName = this->ImageDataSource->getDataFile(0);
-  this->ImageSource.TakeReference(vpImageSourceFactory::GetInstance()->Create(fileName));
+  const auto& fileName = this->ImageDataSource->frameName(0);
+  this->ImageSource.TakeReference(
+    vpImageSourceFactory::GetInstance()->Create(stdString(fileName)));
 
   if (!this->ImageSource)
     {
     QString errorMsg = QString("Unable to create image souce for \"%1\"");
-    emit this->criticalError(errorMsg.arg(qtString(fileName)));
+    emit this->criticalError(errorMsg.arg(fileName));
     return;
     }
 }
@@ -8215,8 +8218,8 @@ void vpViewCore::startFrameMapRebuild()
 //-----------------------------------------------------------------------------
 bool vpViewCore::waitForFrameMapRebuild()
 {
-  int numFiles = this->ImageDataSource->getFileCount();
-  if (!this->FrameMap->isRunning() && this->FrameMap->progress() < numFiles)
+  const auto numFrames = this->ImageDataSource->frames();
+  if (!this->FrameMap->isRunning() && this->FrameMap->progress() < numFrames)
     {
     // This shouldn't ever happen.
     qDebug() << "Trying to wait for frame map build thread to complete, but "
@@ -8225,7 +8228,7 @@ bool vpViewCore::waitForFrameMapRebuild()
     }
 
   QProgressDialog progress("Decoding image timestamps...", "Cancel",
-                           0, numFiles);
+                           0, numFrames);
   progress.setWindowModality(Qt::ApplicationModal);
 
   // Manually force the dialog to be shown. Otherwise, in release builds a
@@ -8234,7 +8237,7 @@ bool vpViewCore::waitForFrameMapRebuild()
   progress.show();
 
   int curProgress;
-  while ((curProgress = this->FrameMap->progress()) < numFiles)
+  while ((curProgress = this->FrameMap->progress()) < numFrames)
     {
     progress.setValue(curProgress);
 
@@ -8250,7 +8253,7 @@ bool vpViewCore::waitForFrameMapRebuild()
       return false;
       }
     }
-  progress.setValue(numFiles);
+  progress.setValue(numFrames);
   return true;
 }
 

--- a/Applications/VpView/vpViewCore.h
+++ b/Applications/VpView/vpViewCore.h
@@ -238,7 +238,7 @@ public:
   int getTrackTypeIndex(const char* typeName);
 
   void updateTrack(vtkVgTrack*, const std::shared_ptr<kwiver::vital::track>&,
-                   const std::map<unsigned int, vgTimeStamp>& timeMap,
+                   const QMap<int, vgTimeStamp>& timeMap,
                    double videoHeight, bool updateToc = false);
 
   void improveTrack(int trackId, int session);


### PR DESCRIPTION
Rewrite the internal logic of vpFileDataSource using Qt, rather than a mix of STL, VTK and kwsys, and refactor the API to use Qt conventions. Overhaul vpFrameMap, making use of Qt data types. Refactor users as needed.

This produces a cleaner and more consistent implementation, and will make some future work easier.