### PR TITLE
Minor fixes

### DIFF
--- a/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
+++ b/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
@@ -68,8 +68,8 @@ kv::track_sptr convertTrack(vtkVgTrack* in, double videoHeight)
 
       const auto frame = timeStamp.GetFrameNumber();
       const auto time = [](const vtkVgTimeStamp& ts){
-        return (ts.HasTime() ? static_cast<kv::time_us_t>(ts.GetTime())
-                              : std::numeric_limits<kv::time_us_t>::min());
+        return (ts.HasTime() ? static_cast<kv::time_usec_t>(ts.GetTime())
+                             : std::numeric_limits<kv::time_usec_t>::min());
       }(timeStamp);
       out->append(
         std::make_shared<kv::object_track_state>(frame, time, obj));

--- a/Applications/VpView/vpKwiverImproveTrackWorker.cxx
+++ b/Applications/VpView/vpKwiverImproveTrackWorker.cxx
@@ -158,8 +158,8 @@ bool vpKwiverImproveTrackWorker::initialize(
 
         const auto frame = timeStamp.GetFrameNumber();
         const auto time = [](const vtkVgTimeStamp& ts){
-          return (ts.HasTime() ? static_cast<kv::time_us_t>(ts.GetTime())
-                               : std::numeric_limits<kv::time_us_t>::min());
+          return (ts.HasTime() ? static_cast<kv::time_usec_t>(ts.GetTime())
+                               : std::numeric_limits<kv::time_usec_t>::min());
         }(timeStamp);
         d->InitialTrack->append(
           std::make_shared<kv::object_track_state>(frame, time, obj));

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -1062,7 +1062,6 @@ int vpViewCore::getTrackTypeIndex(const char* typeName)
 
   vgTrackType type;
   type.SetId(typeName);
-  type.SetColor(0.5, 0.5, 0.0);
 
   this->TrackTypeRegistry->AddType(type);
   return this->TrackTypeRegistry->GetTypeIndex(typeName);


### PR DESCRIPTION
Fix inconsistency in default track type colors (see commit message for details). Adapt to KWIVER upstream renaming `time_us_t` to `time_usec_t`.