### PR TITLE
Adapt to qtScopedSettingGroup rename

### DIFF
--- a/Libraries/VspData/vsEventInfo.cxx
+++ b/Libraries/VspData/vsEventInfo.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -9,7 +9,7 @@
 #include <QColor>
 #include <QSettings>
 
-#include <qtScopedSettingGroup.h>
+#include <qtScopedSettingsGroup.h>
 
 #include <vgEventType.h>
 
@@ -71,18 +71,20 @@ void loadColor(QSettings& settings, double (&color)[3], QString key,
 vsEventInfo eventFromSettings(QSettings& settings, int type,
                               EventInfoTemplate tpl)
 {
-  qtScopedSettingGroup sg(settings, QString::number(type));
-
   vsEventInfo ei;
 
-  ei.type = type;
-  const QString defaultName =
-    (tpl.name ? tpl.name : QString("Unknown type %1").arg(type));
-  ei.name = settings.value("Name", defaultName).toString();
+  with_expr (qtScopedSettingsGroup{settings, QString::number(type)})
+    {
 
-  loadColor(settings, ei.pcolor, "PenColor", tpl.color + 0);
-  loadColor(settings, ei.bcolor, "BackgroundColor", tpl.color + 3);
-  loadColor(settings, ei.fcolor, "ForegroundColor", Qt::white);
+    ei.type = type;
+    const QString defaultName =
+      (tpl.name ? tpl.name : QString("Unknown type %1").arg(type));
+    ei.name = settings.value("Name", defaultName).toString();
+
+    loadColor(settings, ei.pcolor, "PenColor", tpl.color + 0);
+    loadColor(settings, ei.bcolor, "BackgroundColor", tpl.color + 3);
+    loadColor(settings, ei.fcolor, "ForegroundColor", Qt::white);
+    }
 
   return ei;
 }

--- a/Libraries/VvWidgets/vvDescriptorStyleSetting.cxx
+++ b/Libraries/VvWidgets/vvDescriptorStyleSetting.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -9,7 +9,8 @@
 #include <QSettings>
 #include <QStringList>
 
-#include <qtScopedSettingGroup.h>
+#include <qtEnumerate.h>
+#include <qtScopedSettingsGroup.h>
 
 #include "vvDescriptorStyle.h"
 
@@ -70,10 +71,12 @@ void Setting::commit(QSettings& store)
 {
   QVariantHash map = this->currentValue.toHash();
 
-  qtScopedSettingGroup g(store, this->key());
-  foreach_iter (QVariantHash::iterator, iter, map)
+  with_expr (qtScopedSettingsGroup{store, this->key()})
     {
-    store.setValue(iter.key(), iter.value());
+    for (auto iter : qtEnumerate(map))
+      {
+      store.setValue(iter.key(), iter.value());
+      }
     }
 
   this->originalValue = this->currentValue;

--- a/Libraries/VvWidgets/vvScoreGradientSetting.cxx
+++ b/Libraries/VvWidgets/vvScoreGradientSetting.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -11,7 +11,7 @@
 #include <QStringList>
 
 #include <qtMath.h>
-#include <qtScopedSettingGroup.h>
+#include <qtScopedSettingsGroup.h>
 
 #include <vgColor.h>
 
@@ -106,16 +106,17 @@ void vvScoreGradientSetting::commit(QSettings& store)
 
   // Erase old value
   store.remove(this->key());
-  qtScopedSettingGroup g(store, this->key());
-
-  // Write new stops
-  int counter = 0;
-  foreach (const vvScoreGradient::Stop& stop, gradient.stops())
+  with_expr (qtScopedSettingsGroup{store, this->key()})
     {
-    qtScopedSettingGroup sg(store, QString::number(++counter));
-    store.setValue("Name", stop.text);
-    store.setValue("Threshold", stop.threshold);
-    vgColor(stop.color).write(store, "Color");
+    // Write new stops
+    int counter = 0;
+    foreach (const vvScoreGradient::Stop& stop, gradient.stops())
+      {
+      qtScopedSettingsGroup sg(store, QString::number(++counter));
+      store.setValue("Name", stop.text);
+      store.setValue("Threshold", stop.threshold);
+      vgColor(stop.color).write(store, "Color");
+      }
     }
 
   // Mark as committed


### PR DESCRIPTION
Rename use of `qtScopedSettingGroup` → `qtScopedSettingsGroup` per upstream change, and refactor uses to use the recently added `with_expr`.