### PR TITLE
Set TOC's on input tracks to embedded pipeline

### DIFF
--- a/Applications/VpView/vpKwiverEmbeddedPipelineWorker.h
+++ b/Applications/VpView/vpKwiverEmbeddedPipelineWorker.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -23,6 +23,7 @@ class object_track_set;
 
 class vpFileDataSource;
 class vtkVpTrackModel;
+class vtkVgTrackTypeRegistry;
 
 class vpKwiverEmbeddedPipelineWorkerPrivate;
 
@@ -34,8 +35,10 @@ public:
   vpKwiverEmbeddedPipelineWorker(QObject* parent = nullptr);
   ~vpKwiverEmbeddedPipelineWorker();
 
-  bool initialize(const QString& pipelineFile, vpFileDataSource* dataSource,
-                  vtkVpTrackModel* trackModel, double videoHeight);
+  bool initialize(
+    const QString& pipelineFile, vpFileDataSource* dataSource,
+    vtkVpTrackModel* trackModel, vtkVgTrackTypeRegistry const* trackTypes,
+    double videoHeight);
 
   std::shared_ptr<kwiver::vital::object_track_set> tracks() const;
 

--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -8609,7 +8609,8 @@ void vpViewCore::executeEmbeddedPipeline(
   // Set up worker
   vpKwiverEmbeddedPipelineWorker worker;
   if (!worker.initialize(pipelinePath, this->ImageDataSource,
-                         project->TrackModel, videoHeight))
+                         project->TrackModel, this->TrackTypeRegistry,
+                         videoHeight))
     {
     return;
     }


### PR DESCRIPTION
Tweak WAMI Viewer's embedded pipeline support to also supply the TOC to tracks being passed as input to the embedded pipeline.