### PR TITLE
Use full image dimensions when determining need for Y offset

### DIFF
--- a/Applications/VpView/vpViewCore.cxx
+++ b/Applications/VpView/vpViewCore.cxx
@@ -5530,7 +5530,10 @@ void vpViewCore::forceUpdate()
         {
         this->ImageSource->UpdateInformation();
         int dim[2];
-        this->ImageSource->GetDimensions(dim);
+        if (!this->ImageSource->GetRasterDimensions(dim))
+          {
+          this->ImageSource->GetDimensions(dim);
+          }
 
         if (dim[1] != this->FirstImageY)
           {


### PR DESCRIPTION
An image shift is necessary so that the upper left is treated as the origin
if input images do not all have the same height. The logic doing the shift
was incorrectly doing a shift when the input images had the same height but
zooming in (or translating) had caused the reader (vtkVgGDALReader) to only
return a subset of the image.