### PR TITLE
Windows fixes (VIAME)

### DIFF
--- a/Libraries/VtkVgCore/vtkVgPlotTimeline.cxx
+++ b/Libraries/VtkVgCore/vtkVgPlotTimeline.cxx
@@ -232,7 +232,7 @@ struct IdToPointXIter
     : Points(pts), Pointer(start)
     {}
 
-  double operator*()
+  double operator*() const
     { return this->Points[*Pointer].GetX(); }
 
   IdToPointXIter& operator++()

--- a/Plugins/VvQueryService/KipQueryService/vvKipQuerySession.cxx
+++ b/Plugins/VvQueryService/KipQueryService/vvKipQuerySession.cxx
@@ -459,10 +459,11 @@ bool vvKipQuerySessionPrivate::stQueryProcess()
 vvKipQuerySession::vvKipQuerySession(QUrl server)
   : d_ptr(new vvKipQuerySessionPrivate(this, server))
 {
-  static auto const pluginsLoaded [[maybe_unused]] = [](){
+  static auto const pluginsLoaded = [](){
     kwiver::vital::plugin_manager::instance().load_all_plugins();
     return true;
   }();
+  Q_UNUSED(pluginsLoaded)
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR includes fixes to the `viame/master` branch for it to compile on Windows, specifically with Visual Studio 15. Perhaps some of this is also relevant for `master`.

These are largely straightforward changes, but I have a couple concerns:
- What's the canonical place in a `CMakeLists.txt` file to call `add_compile_options`?
- `KipQueryService` requires C++17 because of one use of `[[maybe_unused]]`. Is it worth bumping up the required standard for this?

@mwoehlke-kitware @mattdawkins