### PR TITLE
Fix boost errors

### DIFF
--- a/CMake/coredeps.cmake
+++ b/CMake/coredeps.cmake
@@ -13,7 +13,7 @@ find_package(Qt5 5.8.0 REQUIRED COMPONENTS
 
 # Boost is required.
 find_package(Boost REQUIRED
-  COMPONENTS thread signals system filesystem date_time
+  COMPONENTS thread system filesystem date_time
 )
 add_definitions(-DBOOST_ALL_NO_LIB)
 

--- a/Libraries/VtkVgCore/vtkVgChartTimeline.cxx
+++ b/Libraries/VtkVgCore/vtkVgChartTimeline.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2018 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -44,7 +44,7 @@ boost::gregorian::date GetEpoch()
 boost::posix_time::ptime GetPosixTimeSeconds(double us)
 {
   boost::posix_time::ptime pt(GetEpoch());
-  return pt + boost::posix_time::seconds(us * 1.0e-6);
+  return pt + boost::posix_time::seconds(static_cast<int64_t>(us * 1.0e-6));
 }
 
 boost::posix_time::ptime GetPosixTime(double us)


### PR DESCRIPTION
Remove requirement for `boost::signals`; this library hasn't existed for some time, and does not appear to be in use. Fix an error using `boost::posix_time::seconds`; we were trying to pass a double to this, but only integral types are supported.