### PR TITLE
Add ability to read MIE4NITF files

### DIFF
--- a/Applications/VpView/CMakeLists.txt
+++ b/Applications/VpView/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 # Needed for GDAL readers
 if(VISGUI_ENABLE_GDAL)
-  list(APPEND vgSdkTargets vtkVgIO)
+  list(APPEND vgSdkTargets vtkVgIO ${GDAL_LIBRARY})
 endif()
 
 vg_include_library_sdk_directories(${vgSdkTargets} vvData)

--- a/Applications/VpView/vpFileDataSource.cxx
+++ b/Applications/VpView/vpFileDataSource.cxx
@@ -16,6 +16,12 @@
 #include <QStringList>
 
 #include <algorithm>
+#include <iostream>
+
+#ifdef VISGUI_USE_GDAL
+  #include <gdal_priv.h>
+  #include <cpl_conv.h>
+#endif
 
 namespace // anonymous
 {
@@ -128,6 +134,57 @@ void vpFileDataSource::setMonitoringEnabled(bool enable)
   }
 }
 
+bool add_mie4nitf_subdatasets (const QString &path, QStringList &list) {
+#ifdef VISGUI_USE_GDAL
+    GDALAllRegister();
+
+  GDALDataset *dataset = \
+        static_cast<GDALDataset *>(GDALOpen(path.toStdString().c_str(),
+              GA_ReadOnly));
+
+    if (!dataset)
+    {
+      qWarning().nospace()<< "GDAL could not load file." <<
+        path.toStdString().c_str();
+    }
+
+    const char* subdatasets_domain_name = "SUBDATASETS";
+    char **str = GDALGetMetadata(dataset, subdatasets_domain_name);
+
+    int num_key_val_pairs = 0;
+    while((*str) != NULL) {
+      char *key_c_str= nullptr;
+      QString key, value;
+      const char *val_c_str = CPLParseNameValue((*str), &key_c_str);
+      if (key_c_str != nullptr && val_c_str != nullptr)
+      {
+        key = QString(key_c_str);
+        value = QString(val_c_str);
+	
+	// Subdataset # 2 inside `/A.ntf` would be indicated by:
+        // SUBDATASET_2_NAME=NITF_IM:1:/A.ntf
+        // SUBDATASET_2_DESC=Image 2 of A.ntf
+
+        const QRegExp rgx = QRegExp("SUBDATASET_\\d+_NAME");
+
+        if(key.contains(rgx))
+          list.append(value);
+      }
+      CPLFree(key_c_str);
+      ++(str);
+      ++num_key_val_pairs;
+    }
+    assert(num_key_val_pairs % 2 == 0);
+    assert(num_key_val_pairs / 2 == list.size());
+    GDALClose(dataset);
+    return true;
+#else
+    qWarning() << "ERROR: GDAL reader not found to open file: " <<
+      path.toStdString();
+     return false;
+#endif
+
+}
 //-----------------------------------------------------------------------------
 void vpFileDataSource::update()
 {
@@ -154,21 +211,54 @@ void vpFileDataSource::update()
     {
       while (!file.atEnd())
       {
-        const auto line = file.readLine();
+        QString line = file.readLine().trimmed();
         if (line.isEmpty())
         {
           continue;
         }
 
-        const auto path = baseDir.absoluteFilePath(QString::fromUtf8(line));
-        if (!QFileInfo{path}.exists())
+        // The path we'd check existence of.  It may so happen, like in the case
+        // of MIE4NITF, that the `path` to a frame doesn't exist on the disk.
+        // For ex., in MIE4NITF, frame # 3 inside `/A.ntf` (0-indexed) is
+        // stored in:
+        // `NITF_IM:2:/A.ntf`.
+        QString path_to_check;
+        QStringList all_paths;
+
+        // MIE4NITF are a bunch of frames inside an `NITF` file.  Just like we
+        // use glob to get more than one frames, we use the prefix `MIE4NITF:`
+        // to indicate that this file contains more than one frame in NITF
+        // format.
+        const QString mie4nitf_prefix = "MIE4NITF:";
+
+        if (line.startsWith(mie4nitf_prefix))
         {
-          qWarning() << "Image data file" << path << "does not exist";
+          int L = mie4nitf_prefix.length();
+          QString p = line.mid(L);
+          path_to_check = baseDir.absoluteFilePath(p);
+
+          if(!add_mie4nitf_subdatasets(path_to_check, all_paths))
+          {
+            continue;
+          }
+        }
+        else
+        {
+          path_to_check = baseDir.absoluteFilePath(line);
+          all_paths.append(path_to_check);
+        }
+
+        if (!QFileInfo{path_to_check}.exists())
+        {
+          qWarning() << "Image data file" << path_to_check << "does not exist";
           continue;
         }
 
-        qDebug() << "Archiving" << path;
-        d->DataFiles.append(path);
+        for(auto path: all_paths)
+        {
+          qDebug() << "Archiving" << path;
+          d->DataFiles.append(path);
+        }
       }
     }
     else

--- a/Libraries/VtkVgIO/vtkGDALReader.cxx
+++ b/Libraries/VtkVgIO/vtkGDALReader.cxx
@@ -138,6 +138,7 @@ void vtkGDALReader::vtkGDALReaderInternal::ReadMetaData(
   this->ReleaseData();
 
   this->GDALData = (GDALDataset*) GDALOpen(fileName.c_str(), GA_ReadOnly);
+  std::cout << "Using GDAL reader to open file: " << fileName << std::endl;
 
   if (this->GDALData == NULL)
     {


### PR DESCRIPTION
To read an MIE4NITF file, we do the following:

1. In the project file, say `test_project.prj`, we specify the absolute path to an image list file.
2. In the image list file, which is assumed to be in the same directory as the frames, we indicate MIE4NITF file using the prefix `MIE4NITF:`.

For example:

```
$ cat test_project.prj  
DataSetSpecifier=/home/chaturvedi/images/all_images.txt

-----

$ cat /home/chaturvedi/images/all_images.txt
frame__071.ntf
frame__072.ntf
frame__073.ntf
frame__074.ntf
frame__075.ntf
MIE4NITF:wpr-j2k.r0t0q0c1i1.NTF

-----

$ ls --format=single-column /home/chaturvedi/images/
all_images.txt
frame__001.ntf
frame__002.ntf
frame__071.ntf
frame__072.ntf
frame__073.ntf
frame__074.ntf
frame__075.ntf
wpr-j2k.r0t0q0c1i1.NTF
```

Note that `/home/chaturvedi/images/` may contain more files than what are used.