### PR TITLE
Fix sprokit link error

### DIFF
--- a/Applications/VpView/CMakeLists.txt
+++ b/Applications/VpView/CMakeLists.txt
@@ -304,7 +304,7 @@ target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
 
 if(VISGUI_ENABLE_KWIVER)
   target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
-    kwiver::sprokit_tools
+    kwiver::sprokit_pipeline
     kwiver::kwiver_adapter
     kwiver::kwiver_algo_vxl
     kwiver::kwiver_algo_core


### PR DESCRIPTION
The `kwiver::sprokit_tools` library was removed from KWIVER. I'm not sure why we were linking this originally, but `sprokit_pipeline` seems sufficient; link to that instead.