### PR TITLE
CMake improvements

### DIFF
--- a/Applications/Viqui/CMakeLists.txt
+++ b/Applications/Viqui/CMakeLists.txt
@@ -83,6 +83,7 @@ set(vqSources
     vqResultInfo.cxx
     vqSettings.cxx
     vqTimeline.cxx
+    vqTrackingClipBuilder.cxx
     vqTrackingClipViewer.cxx
     vqTreeView.cxx
     vqUserActions.cxx
@@ -95,43 +96,11 @@ set(vqSources
     Backends/vqVqrExporter.cxx
 )
 
-set(vqUI
-    classifierQuery.ui
-    configure.ui
-    predefinedQuery.ui
-    query.ui
-    regionEdit.ui
-    resultFilter.ui
-    resultInfo.ui
-    viqui.ui
+set(vqResSources
+  ../../Icons/stdbutton.qrc
+  ../../Icons/viqui.qrc
+  ../../Icons/vgvideo.qrc
 )
-
-set(vqMocHeaders
-    vqApplication.h
-    vqArchiveVideoSource.h
-    vqClassifierQueryDialog.h
-    vqConfigureDialog.h
-    vqCore.h
-    vqPredefinedQueryCache.h
-    vqPredefinedQueryCachePrivate.h
-    vqPredefinedQueryDialog.h
-    vqQueryDialog.h
-    vqQueryParser.h
-    vqQueryVideoPlayer.h
-    vqRegionEditDialog.h
-    vqResultFilterDialog.h
-    vqResultInfo.h
-    vqTimeline.h
-    vqTrackingClipBuilder.h
-    vqTrackingClipViewer.h
-    vqTreeView.h
-    vqUserActions.h
-    vqVideoPlayer.h
-    vqVideoQueryDialog.h
-    vtkVQBlastLayoutNode.h
-)
-
-set(vqResources ../../Icons/stdbutton.qrc ../../Icons/viqui.qrc ../../Icons/vgvideo.qrc)
 
 # END core program code
 
@@ -139,31 +108,8 @@ set(vqResources ../../Icons/stdbutton.qrc ../../Icons/viqui.qrc ../../Icons/vgvi
 
 # BEGIN build rules
 
-qt5_wrap_ui(uiSources ${vqUI})
-qt5_wrap_cpp(mocSources ${vqMocHeaders})
-qt5_add_resources(resSources ${vqResources})
-
-source_group("User Interface" FILES
-  ${vqUI}
-)
-
-source_group("Resources" FILES
-  ${vqUI}
-  ${EXE_ICON}
-)
-
-source_group("Generated" FILES
-  ${uiSources}
-  ${mocSources}
-  ${resSources}
-)
-
-set_source_files_properties(${vqSources}
-  PROPERTIES OBJECT_DEPENDS "${uiSources}"
-)
-
 add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE
-  ${vqSources} ${uiSources} ${mocSources} ${resSources}
+  ${vqSources} ${vqResSources}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/Applications/Viqui/CMakeLists.txt
+++ b/Applications/Viqui/CMakeLists.txt
@@ -51,8 +51,6 @@ set(vgSdkTargets
   vvWidgets
 )
 
-vg_include_library_sdk_directories(${vgSdkTargets})
-
 # Configure file here
 include(vqVersion.cmake)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/vqVersion.h.in

--- a/Applications/Viqui/vqPredefinedQueryCache.cxx
+++ b/Applications/Viqui/vqPredefinedQueryCache.cxx
@@ -1,11 +1,10 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include "vqPredefinedQueryCache.h"
-#include "vqPredefinedQueryCachePrivate.h"
+#include "moc_vqPredefinedQueryCachePrivate.cpp"
 
 #include <QApplication>
 #include <QDebug>

--- a/Applications/Viqui/vqTrackingClipBuilder.cxx
+++ b/Applications/Viqui/vqTrackingClipBuilder.cxx
@@ -1,0 +1,148 @@
+/*ckwg +5
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "vqTrackingClipBuilder.h"
+
+#include <vtkImageData.h>
+
+#include <qtGlobal.h>
+
+#include <QMutexLocker>
+
+#include <algorithm>
+
+namespace // anonymous
+{
+
+using ClipElement = vqTrackingClipBuilder::ClipElement;
+
+//-----------------------------------------------------------------------------
+struct CompareClipDuration
+{
+  bool operator()(const ClipElement& c1, const ClipElement& c2)
+  {
+    return c1.second->GetDuration() < c2.second->GetDuration();
+  }
+};
+
+} // namespace <anonymous>
+
+//-----------------------------------------------------------------------------
+vqTrackingClipBuilder::vqTrackingClipBuilder()
+{
+}
+
+//-----------------------------------------------------------------------------
+vqTrackingClipBuilder::~vqTrackingClipBuilder()
+{
+  this->disconnect();
+  this->Shutdown();
+  this->wait();
+}
+
+//-----------------------------------------------------------------------------
+void vqTrackingClipBuilder::BuildClips(
+  ClipVector::iterator start, ClipVector::iterator end)
+{
+  static CompareClipDuration comparator;
+
+  // Note: Clips may not become available in the order they were submitted.
+  // Shorter clips will be processed before longer ones.
+
+  // If the build thread has the first vector locked, put incoming clips into
+  // the 'backup'. Since the build thread only holds one of these locks at
+  // a time, we can acquire one here without blocking. This is the only
+  // function that modifies the clip vectors.
+  if (this->ClipsMutex[0].tryLock())
+  {
+    this->Clips[0].insert(this->Clips[0].end(), start, end);
+    std::sort(this->Clips[0].begin(), this->Clips[0].end(), comparator);
+    this->ClipsMutex[0].unlock();
+  }
+  else
+  {
+    synchronized (&this->ClipsMutex[1])
+    {
+      this->Clips[1].insert(this->Clips[1].end(), start, end);
+      std::sort(this->Clips[1].begin(), this->Clips[1].end(), comparator);
+    }
+  }
+
+  this->start();
+}
+
+//-----------------------------------------------------------------------------
+void vqTrackingClipBuilder::SkipClip(int id)
+{
+  // Search for the clip and mark it to be skipped if found. There is no race
+  // here since this function is called from the same thread as BuildClips().
+  for (auto& clips : this->Clips)
+  {
+    for (auto& clip : clips)
+    {
+      if (clip.first == id)
+      {
+        synchronized (&this->ClipIdMutex)
+        {
+          clip.first = -1;
+        }
+        break;
+      }
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+void vqTrackingClipBuilder::Shutdown()
+{
+  this->ShutdownRequested = true;
+}
+
+//-----------------------------------------------------------------------------
+void vqTrackingClipBuilder::run()
+{
+  // Keep switching between the two input vectors until there are no new clips
+  // left to process. This will usually complete in one iteration, but will
+  // require more if new clips get added before processing completes.
+  for (int i = 0; ; i = !i)
+  {
+    synchronized (&this->ClipsMutex[i])
+    {
+      if (this->Clips[i].empty())
+      {
+        break;
+      }
+
+      for (const auto& clip : this->Clips[i])
+      {
+        if (this->ShutdownRequested)
+        {
+          return;
+        }
+
+        int id;
+        synchronized (&this->ClipIdMutex)
+        {
+          id = clip.first;
+        }
+
+        if (id >= 0)
+        {
+          vtkImageData* output = clip.second->GetOutputImageData();
+
+          // Caller will need to Delete() the image data once it has been
+          // received. This is to ensure the data keeps a reference count > 0
+          // between the time when the signal is emitted until it is received.
+          output->Register(0);
+
+          emit this->ClipAvailable(output, id);
+        }
+      }
+
+      this->Clips[i].clear();
+    }
+  }
+}

--- a/Applications/Viqui/vqTrackingClipBuilder.h
+++ b/Applications/Viqui/vqTrackingClipBuilder.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -9,159 +9,45 @@
 
 #include "vtkVQTrackingClip.h"
 
-#include <vtkImageData.h>
-
-#include <QMutexLocker>
+#include <QMutex>
 #include <QThread>
 
-#include <algorithm>
+#include <array>
+#include <atomic>
 #include <vector>
 
-typedef std::pair< int, vtkSmartPointer<vtkVQTrackingClip> > ClipElement;
-typedef std::vector<ClipElement> ClipVector;
+class vtkImageData;
 
-namespace
-{
-
-//-----------------------------------------------------------------------------
-struct CompareClipDuration
-{
-  bool operator()(const ClipElement& c1, const ClipElement& c2)
-    {
-    return c1.second->GetDuration() < c2.second->GetDuration();
-    }
-};
-
-}
-
-//-----------------------------------------------------------------------------
 class vqTrackingClipBuilder : public QThread
 {
   Q_OBJECT
 
 public:
-  vqTrackingClipBuilder()
-    : QThread(), ShutdownRequested(false)
-    { }
+  using ClipElement = std::pair<int, vtkSmartPointer<vtkVQTrackingClip>>;
+  using ClipVector = std::vector<ClipElement>;
 
-  ~vqTrackingClipBuilder()
-    {
-    this->disconnect();
-    this->Shutdown();
-    this->wait();
-    }
+  vqTrackingClipBuilder();
+  virtual ~vqTrackingClipBuilder();
 
-  void BuildClips(ClipVector::iterator start, ClipVector::iterator end)
-    {
-    // Note: Clips may not become available in the order they were submitted.
-    // Shorter clips will be processed before longer ones.
+  void BuildClips(ClipVector::iterator start, ClipVector::iterator end);
 
-    // If the build thread has the first vector locked, put incoming clips into
-    // the 'backup'. Since the build thread only holds one of these locks at
-    // a time, we can acquire one here without blocking. This is the only
-    // function that modifies the clip vectors.
-    if (this->ClipsMutex[0].tryLock())
-      {
-      this->Clips[0].insert(this->Clips[0].end(), start, end);
-      std::sort(this->Clips[0].begin(), this->Clips[0].end(), CompareClipDuration());
-      this->ClipsMutex[0].unlock();
-      }
-    else
-      {
-      QMutexLocker x(&this->ClipsMutex[1]);
-      this->Clips[1].insert(this->Clips[1].end(), start, end);
-      std::sort(this->Clips[1].begin(), this->Clips[1].end(), CompareClipDuration());
-      }
+  void SkipClip(int id);
 
-    this->start();
-    }
-
-  void SkipClip(int id)
-    {
-    // Search for the clip and mark it to be skipped if found. There is no
-    // race here since this function is called from the same thread as
-    // BuildClips().
-    for (int i = 0; i < 2; ++i)
-      {
-      for (ClipVector::iterator itr = this->Clips[i].begin(),
-           end = this->Clips[i].end(); itr != end; ++itr)
-        {
-        if (itr->first == id)
-          {
-          QMutexLocker x(&this->ClipIdMutex);
-          itr->first = -1;
-          break;
-          }
-        }
-      }
-    }
-
-  void Shutdown()
-    {
-    QMutexLocker x(&this->ShutdownMutex);
-    this->ShutdownRequested = true;
-    }
+  void Shutdown();
 
 signals:
   void ClipAvailable(vtkImageData* clip, int index);
 
 protected:
-  virtual void run()
-    {
-    // Keep switching between the two input vectors until there are no new clips
-    // left to process. This will usually complete in one iteration, but will
-    // require more if new clips get added before processing completes.
-    for (int i = 0; ; i = !i)
-      {
-      QMutexLocker x(&this->ClipsMutex[i]);
-
-      if (this->Clips[i].empty())
-        {
-        break;
-        }
-
-      for (ClipVector::const_iterator itr = this->Clips[i].begin(),
-           end = this->Clips[i].end(); itr != end; ++itr)
-        {
-          {
-          QMutexLocker x(&this->ShutdownMutex);
-          if (this->ShutdownRequested)
-            {
-            return;
-            }
-          }
-
-        int id;
-          {
-          QMutexLocker x(&this->ClipIdMutex);
-          id = itr->first;
-          }
-
-        if (id >= 0)
-          {
-          vtkImageData* output = itr->second->GetOutputImageData();
-
-          // Caller will need to Delete() the image data once it has been
-          // received. This is to ensure the data keeps a reference count> 0
-          // between the time when the signal is emitted until it is received.
-          output->Register(0);
-
-          emit this->ClipAvailable(output, id);
-          }
-        }
-      this->Clips[i].clear();
-      }
-    }
+  virtual void run() override;
 
 private:
-  bool ShutdownRequested;
+  std::atomic<bool> ShutdownRequested{false};
 
-  ClipVector Clips[2];
+  std::array<ClipVector, 2> Clips;
+  std::array<QMutex, 2> ClipsMutex;
 
-  QMutex ShutdownMutex;
   QMutex ClipIdMutex;
-
-  QMutex ClipsMutex[2];
 };
 
 #endif // __vqTrackingClipBuilder_h

--- a/Applications/Viqui/vqTrackingClipViewer.cxx
+++ b/Applications/Viqui/vqTrackingClipViewer.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -54,7 +54,8 @@ enum
 
 struct CompareByRank
 {
-  bool operator()(const ClipElement& c1, const ClipElement& c2)
+  bool operator()(const vqTrackingClipBuilder::ClipElement& c1,
+                  const vqTrackingClipBuilder::ClipElement& c2)
     {
     return c1.second->GetRank() < c2.second->GetRank();
     }

--- a/Applications/VpView/CMakeLists.txt
+++ b/Applications/VpView/CMakeLists.txt
@@ -86,8 +86,6 @@ if(VISGUI_ENABLE_SUPER3D)
   link_directories(${OpenCV_LIB_DIR})
 endif()
 
-vg_include_library_sdk_directories(${vgSdkTargets} vvData)
-
 # Configure version file
 include(vpVersion.cmake)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/vpVersion.h.in
@@ -330,7 +328,8 @@ add_executable(${PROJECT_NAME} ${ExecProperties}
   ${vpViewSources} ${vpViewHeaders} ${uiSources} ${mocSources} ${resSources}
 )
 
-target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
   ${vgSdkTargets}
   vgl vnl vul vil_io
   GeographicLib::GeographicLib
@@ -343,7 +342,8 @@ target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
 )
 
 if(VISGUI_ENABLE_KWIVER)
-  target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
     kwiver::sprokit_pipeline
     kwiver::kwiver_adapter
     kwiver::kwiver_algo_vxl
@@ -352,7 +352,8 @@ if(VISGUI_ENABLE_KWIVER)
 endif()
 
 if(VISGUI_ENABLE_VIDTK)
-  target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
     vidtk_activity_detectors_lib
     vidtk_events_lib
     vidtk_tracking
@@ -361,7 +362,8 @@ if(VISGUI_ENABLE_VIDTK)
 endif()
 
 if(VISGUI_ENABLE_SUPER3D)
-  target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
     imesh
     imesh_algo
     maptk_ocv

--- a/Applications/VpView/CMakeLists.txt
+++ b/Applications/VpView/CMakeLists.txt
@@ -102,6 +102,7 @@ set(vpViewSources
   vpActivityConfig.cxx
   vpActivityIO.cxx
   vpAnnotation.cxx
+  vpApplication.cxx
   vpAttributeConfig.cxx
   vpBox.cxx
   vpConfigUtils.cxx
@@ -145,6 +146,7 @@ set(vpViewSources
   vpSelectTimeIntervalDialog.cxx
   vpSessionView.cxx
   vpSettings.cxx
+  vpTabWidget.cxx
   vpTimelineDialog.cxx
   vpTrackAttributesPanel.cxx
   vpTrackColorDialog.cxx
@@ -158,73 +160,7 @@ set(vpViewSources
   vtkVpTrackModel.cxx
 )
 
-set(vpViewUI
-  qtInformaticsDialog.ui
-  qtNormalcyDialog.ui
-  qtRenderWindowDialog.ui
-  vpConfigure.ui
-  vpCreateEventDialog.ui
-  vpEditTrackTypesDialog.ui
-  vpExternalProcessDialog.ui
-  vpGraphModelWidget.ui
-  vpMergeTracksDialog.ui
-  vpObjectInfoPanel.ui
-  vpObjectSelectionPanel.ui
-  vpProjectEditor.ui
-  vpQtViewer3dDialog.ui
-  vpQtViewer3dWidget.ui
-  vpSelectTimeIntervalDialog.ui
-  vpTimelineDialog.ui
-  vpTrackAttributeColorDialog.ui
-  vpTrackAttributesPanel.ui
-  vpTrackColorDialog.ui
-  vpView.ui
-)
-
-if(VISGUI_ENABLE_SUPER3D)
-  list(APPEND vpViewUI
-    vpSuperResDepthViewer.ui
-    vpSuperResViewer.ui
-    vpSuperResWidget.ui
-    )
-endif()
-
-set(vpViewHeaders
-  vpApplication.h
-  vpConfigureDialog.h
-  vpCreateEventDialog.h
-  vpEditTrackTypesDialog.h
-  vpEntityConfigWidget.h
-  vpExternalProcessDialog.h
-  vpFileDataSource.h
-  vpGraphModelHelper.h
-  vpGraphModelView.h
-  vpGraphModelWidget.h
-  vpFrameMap.h
-  vpInformaticsDialog.h
-  vpMergeTracksDialog.h
-  vpObjectInfoPanel.h
-  vpObjectSelectionPanel.h
-  vpProject.h
-  vpProjectEditor.h
-  vpProjectList.h
-  vpQtViewer3d.h
-  vpQtViewer3dDialog.h
-  vpQtViewer3dWidget.h
-  vpSelectTimeIntervalDialog.h
-  vpSessionView.h
-  vpTimelineDialog.h
-  vpTabWidget.h
-  vpTrackAttributesPanel.h
-  vpTrackColorDialog.h
-  vpTreeView.h
-  vpVideoAnimation.h
-  vpView.h
-  vpViewCore.h
-  vtkVpTrackModel.h
-)
-
-set(vpViewResources ../../Icons/vpView.qrc)
+set(vpViewResSources ../../Icons/vpView.qrc)
 
 # END core program code
 
@@ -254,18 +190,6 @@ if(VISGUI_ENABLE_VIDTK)
     vpVidtkIO.cxx
     vpVidtkTrackIO.cxx
   )
-
-  if(VISGUI_ENABLE_SUPER3D)
-    list(APPEND vpViewHeaders
-      vpSuperResDepthWarper.h
-      vpSuperResDepthViewer.h
-      vpSuperResHomogWarper.h
-      vpSuperResViewer.h
-      vpSuperResWarper.h
-      vpSuperResWidget.h
-      vpSuperResWorker.h
-      )
-  endif()
 else()
   list(APPEND vpViewSources
     vpVdfIO.cxx
@@ -285,11 +209,6 @@ if(VISGUI_ENABLE_KWIVER)
     vpKwiverImproveTrackWorker.cxx
     vpKwiverVideoSource.cxx
   )
-
-  list(APPEND vpViewHeaders
-    vpKwiverEmbeddedPipelineWorker.h
-    vpKwiverImproveTrackWorker.h
-  )
 endif()
 
 # END OPTIONAL kwiver integration
@@ -297,25 +216,6 @@ endif()
 ###############################################################################
 
 # BEGIN build rules
-
-qt5_wrap_ui(uiSources ${vpViewUI})
-qt5_wrap_cpp(mocSources ${vpViewHeaders})
-qt5_add_resources(resSources ${vpViewResources})
-
-source_group("Resources" FILES
-  ${vpViewUI}
-  ${EXE_ICON}
-)
-
-source_group("Generated" FILES
-  ${uiSources}
-  ${mocSources}
-  ${ResourceSources}
-)
-
-set_source_files_properties(${vpViewSources}
-  PROPERTIES OBJECT_DEPENDS "${uiSources}"
-)
 
 # Hide the console window on release builds
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -325,7 +225,7 @@ endif()
 set(ExecProperties ${ExecProperties} MACOSX_BUNDLE)
 
 add_executable(${PROJECT_NAME} ${ExecProperties}
-  ${vpViewSources} ${vpViewHeaders} ${uiSources} ${mocSources} ${resSources}
+  ${vpViewSources} ${vpViewResSources}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/Applications/VpView/Testing/CMakeLists.txt
+++ b/Applications/VpView/Testing/CMakeLists.txt
@@ -2,7 +2,6 @@
 vg_add_test(vpView-FileDataSource testFileDataSource
   ARGS ${VISGUI_DATA_ROOT}/CLIF/images/*.png ${VISGUI_DATA_ROOT}/CLIF/images.txt
   SOURCES testFileDataSource.cxx ../vpFileDataSource.cxx
-  MOC_HEADERS ../vpFileDataSource.h
   LINK_LIBRARIES vtksys vtkFiltersGeneral vtkIOCore
 )
 

--- a/Applications/VpView/vpApplication.cxx
+++ b/Applications/VpView/vpApplication.cxx
@@ -1,0 +1,4 @@
+// This file exists only to trigger CMake automoc to include the MOC source for
+// the vpApplication class, which requires that the source file name exactly
+// match the header file name. As a purely inline class (aside from the MOC
+// parts), the implementation can be found in the header file.

--- a/Applications/VpView/vpTabWidget.cxx
+++ b/Applications/VpView/vpTabWidget.cxx
@@ -1,0 +1,28 @@
+/*ckwg +5
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
+ * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
+ * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
+ */
+
+#include "vpTabWidget.h"
+
+//-----------------------------------------------------------------------------
+vpTabWidget::vpTabWidget(QWidget* parent) : QTabWidget(parent)
+{
+}
+
+//-----------------------------------------------------------------------------
+vpTabWidget::~vpTabWidget()
+{
+}
+
+//-----------------------------------------------------------------------------
+void vpTabWidget::contextMenuEvent(QContextMenuEvent* event)
+{
+  int tab = this->tabBar()->tabAt(event->pos());
+  if (tab >= 0)
+  {
+    this->setCurrentIndex(tab);
+    emit tabBarContextMenu(event, tab);
+  }
+}

--- a/Applications/VpView/vpTabWidget.h
+++ b/Applications/VpView/vpTabWidget.h
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -16,22 +16,14 @@ class vpTabWidget : public QTabWidget
   Q_OBJECT
 
 public:
-  vpTabWidget(QWidget* parent = 0) : QTabWidget(parent) { }
-  virtual ~vpTabWidget() { }
+  vpTabWidget(QWidget* parent = 0);
+  virtual ~vpTabWidget();
 
 signals:
   void tabBarContextMenu(QContextMenuEvent* event, int index);
 
 protected:
-  virtual void contextMenuEvent(QContextMenuEvent* event)
-    {
-    int tab = this->tabBar()->tabAt(event->pos());
-    if (tab >= 0)
-      {
-      this->setCurrentIndex(tab);
-      emit tabBarContextMenu(event, tab);
-      }
-    }
+  virtual void contextMenuEvent(QContextMenuEvent* event);
 };
 
 #endif

--- a/Applications/VsPlay/CMakeLists.txt
+++ b/Applications/VsPlay/CMakeLists.txt
@@ -35,8 +35,6 @@ set(vspSdkTargets
   vspUserInterface # Inherit the rest of our dependencies from this
 )
 
-vg_include_library_sdk_directories(${vspSdkTargets})
-
 # Configure version header here
 include(vsVersion.cmake)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/vsVersion.h.in
@@ -141,7 +139,8 @@ add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE
 # Built-in plugins should be considered static plugins
 target_compile_definitions(${PROJECT_NAME} PRIVATE QT_STATICPLUGIN)
 
-target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
   ${vspSdkTargets}
   ${QT_TESTING_SUPPORT_LIBRARIES}
   Qt5::Network

--- a/Applications/VsPlay/CMakeLists.txt
+++ b/Applications/VsPlay/CMakeLists.txt
@@ -60,22 +60,6 @@ set(vspPluginSources
     Plugins/vsVvqsDatabaseSourcePlugin.cxx
 )
 
-set(vspPluginMocHeaders
-    # Archive sources
-    Plugins/vsVideoArchiveSourcePlugin.h
-    Plugins/vsTrackArchiveSourcePlugin.h
-    Plugins/vsDescriptorArchiveSourcePlugin.h
-    # Other sources
-    Plugins/vsVvqsDatabaseQueryDialog.h
-    Plugins/vsVvqsDatabaseSource.h
-    Plugins/vsVvqsDatabaseSourcePrivate.h
-    Plugins/vsVvqsDatabaseSourcePlugin.h
-)
-
-set(vspPluginUI
-    Plugins/vvqsDatabaseQuery.ui
-)
-
 # END built-in plugins
 
 ###############################################################################
@@ -89,15 +73,7 @@ set(vspSources
     ${vspPluginSources}
 )
 
-set(vspUI
-    ${vspPluginUI}
-)
-
-set(vspMocHeaders
-    ${vspPluginMocHeaders}
-)
-
-set(vspResources
+set(vspResSources
   ../../Icons/stdbutton.qrc
   ../../Icons/vgvideo.qrc
   ../../Icons/vsp.qrc
@@ -109,31 +85,8 @@ set(vspResources
 
 # BEGIN build rules
 
-qt5_wrap_ui(uiSources ${vspUI})
-qt5_wrap_cpp(mocSources ${vspMocHeaders})
-qt5_add_resources(resSources ${vspResources})
-
-source_group("User Interface" FILES
-  ${vspUI}
-)
-
-source_group("Resources" FILES
-  ${vspUI}
-  ${EXE_ICON}
-)
-
-source_group("Generated" FILES
-  ${uiSources}
-  ${mocSources}
-  ${resSources}
-)
-
-set_source_files_properties(${vspSources}
-  PROPERTIES OBJECT_DEPENDS "${uiSources}"
-)
-
 add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE
-  ${vspSources} ${uiSources} ${mocSources} ${resSources}
+  ${vspSources} ${vspResSources}
 )
 
 # Built-in plugins should be considered static plugins

--- a/Applications/VsPlay/Plugins/vsDescriptorArchiveSourcePlugin.cxx
+++ b/Applications/VsPlay/Plugins/vsDescriptorArchiveSourcePlugin.cxx
@@ -5,6 +5,7 @@
  */
 
 #include "vsDescriptorArchiveSourcePlugin.h"
+#include "moc_vsDescriptorArchiveSourcePlugin.cpp"
 
 #include <QtPlugin>
 

--- a/Applications/VsPlay/Plugins/vsTrackArchiveSourcePlugin.cxx
+++ b/Applications/VsPlay/Plugins/vsTrackArchiveSourcePlugin.cxx
@@ -5,6 +5,7 @@
  */
 
 #include "vsTrackArchiveSourcePlugin.h"
+#include "moc_vsTrackArchiveSourcePlugin.cpp"
 
 #include <QtPlugin>
 

--- a/Applications/VsPlay/Plugins/vsVideoArchiveSourcePlugin.cxx
+++ b/Applications/VsPlay/Plugins/vsVideoArchiveSourcePlugin.cxx
@@ -5,6 +5,7 @@
  */
 
 #include "vsVideoArchiveSourcePlugin.h"
+#include "moc_vsVideoArchiveSourcePlugin.cpp"
 
 #include <QtPlugin>
 

--- a/Applications/VsPlay/Plugins/vsVvqsDatabaseSource.cxx
+++ b/Applications/VsPlay/Plugins/vsVvqsDatabaseSource.cxx
@@ -4,7 +4,7 @@
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include "vsVvqsDatabaseSourcePrivate.h"
+#include "moc_vsVvqsDatabaseSourcePrivate.cpp"
 
 #include <vsAdapt.h>
 

--- a/Applications/VsPlay/Plugins/vsVvqsDatabaseSourcePlugin.cxx
+++ b/Applications/VsPlay/Plugins/vsVvqsDatabaseSourcePlugin.cxx
@@ -5,6 +5,7 @@
  */
 
 #include "vsVvqsDatabaseSourcePlugin.h"
+#include "moc_vsVvqsDatabaseSourcePlugin.cpp"
 
 #include <QSignalMapper>
 #include <QtPlugin>

--- a/CMake/coredeps.cmake
+++ b/CMake/coredeps.cmake
@@ -11,6 +11,10 @@ find_package(Qt5 5.8.0 REQUIRED COMPONENTS
   Xml
 )
 
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
 # Generally, Boost is built shared, but give an advanced option to find a static build.
 option(USE_STATIC_BOOST
   "Find a static build of Boost"

--- a/CMake/testing.cmake
+++ b/CMake/testing.cmake
@@ -15,26 +15,12 @@ function(vg_add_test)
     shift_arg(test_name ${ARGN})
   endif()
   shift_arg(test_executable ${ARGN})
-  set(_opts "_srcs=SOURCES;_moc=MOC_HEADERS;_res=RESOURCES;_ui=UI")
+  set(_opts "_srcs=SOURCES")
   set(_opts "${_opts};_libs=LINK_LIBRARIES;_args=ARGS")
   extract_args("${_opts}" ${ARGN})
   set(_srcs ${_srcs} ${ARGN}) # Use leftover args as sources
 
   if(NOT TARGET ${test_executable})
-    # Handle Qt executables
-    if(NOT "x_${_moc}" STREQUAL "x_")
-      qt5_wrap_cpp(_moc_srcs ${_moc})
-      set(_srcs ${_srcs} ${_moc_srcs})
-    endif()
-    if(NOT "x_${_ui}" STREQUAL "x_")
-      qt5_wrap_ui(_ui_srcs ${_ui})
-      set(_srcs ${_srcs} ${_ui_srcs})
-    endif()
-    if(NOT "x_${_res}" STREQUAL "x_")
-      qt5_add_resources(_res_srcs ${_res})
-      set(_srcs ${_srcs} ${_res_srcs})
-    endif()
-
     # Generate test executable
     add_executable(${test_executable} ${_srcs})
     target_link_libraries(${test_executable} ${_libs} ${VGTEST_LINK_LIBRARIES})

--- a/CMake/wrapping.cmake
+++ b/CMake/wrapping.cmake
@@ -196,12 +196,10 @@ function(vg_wrap_library NAME)
   )
   include_directories(${_extra_include_dirs})
   vg_add_sbk_library(${_pyname} ${_sources})
-  vg_add_dependencies(${_pyname}
-    PRIVATE_INTERFACE_TARGETS
+  target_link_libraries(${_pyname}
+    PRIVATE
     ${NAME}
     ${_DEPENDS}
-    LINK_LIBRARIES
-    LINK_PRIVATE
     ${SHIBOKEN_PYTHON_LIBRARIES}
     ${SHIBOKEN_LIBRARY}
     ${_extra_link_libraries}
@@ -236,12 +234,6 @@ endfunction()
 # Function to wrap a library using VTK
 function(vg_wrap_vtk_library NAME)
   if(VISGUI_ENABLE_PYTHON)
-    # Temporarily unset VisGUI module include directories, as VTK uses the same
-    # name, and we need VTK to see a different directory list (must remove it
-    # from cache or vtk_module_load will not be able to populate it)
-    set(_old_include_dirs "${${NAME}_INCLUDE_DIRS}")
-    unset(${NAME}_INCLUDE_DIRS CACHE)
-
     vtk_module_load("${NAME}")
     vtk_module_headers_load("${NAME}")
 
@@ -262,9 +254,5 @@ function(vg_wrap_vtk_library NAME)
     list(REMOVE_DUPLICATES ${NAME}_INCLUDE_DIRS)
 
     vtk_add_python_wrapping("${NAME}")
-
-    # Restore VisGUI module include directories
-    set(${NAME}_INCLUDE_DIRS)
-    vg_target_include_directories(${NAME} ${_old_include_dirs})
   endif()
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ vg_generate_export_header(
   "${PROJECT_BINARY_DIR}/vgExport.h"
   "${PROJECT_SOURCE_DIR}/vgExport.cmake"
 )
+add_library(${PROJECT_NAME} INTERFACE)
 install_headers("${PROJECT_BINARY_DIR}/vgExport.h" TARGET ${PROJECT_NAME})
 
 # Create package config for build directory

--- a/Libraries/QtTestingSupport/CMakeLists.txt
+++ b/Libraries/QtTestingSupport/CMakeLists.txt
@@ -2,22 +2,6 @@ project(qtTestingSupport)
 
 link_directories(${QtTesting_LIBRARY_DIR})
 
-qt5_wrap_cpp(qtTestingSupportMocSrcs
-  pqCoreTestUtility.h
-  pqFileDialogEventPlayer.h
-  pqFileDialogEventTranslator.h
-  pqInvokeMethodEventPlayer.h
-  pqQDialogButtonBoxEventPlayer.h
-  pqQDialogButtonBoxEventTranslator.h
-  pqQteDoubleSliderEventPlayer.h
-  pqQteDoubleSliderEventTranslator.h
-  pqQVTKWidgetEventTranslator.h
-  pqVgMixerEventPlayer.h
-  pqVgMixerEventTranslator.h
-  pqXMLEventObserver.h
-  pqXMLEventSource.h
-)
-
 set(qtTestingSupportSrcs
   pqCoreTestUtility.cxx
   pqFileDialogEventPlayer.cxx
@@ -37,7 +21,6 @@ set(qtTestingSupportSrcs
 
 add_library(${PROJECT_NAME}
   ${qtTestingSupportSrcs}
-  ${qtTestingSupportMocSrcs}
 )
 
 target_include_directories(${PROJECT_NAME} SYSTEM

--- a/Libraries/QtTestingSupport/CMakeLists.txt
+++ b/Libraries/QtTestingSupport/CMakeLists.txt
@@ -1,16 +1,7 @@
-# Name of the project.
 project(qtTestingSupport)
 
-# Requires Qt and QtTesting.
-include_directories(
-  ${QtTesting_INCLUDE_DIRS}
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${vtkGUISupportQt_INCLUDE_DIRS}
-  )
+link_directories(${QtTesting_LIBRARY_DIR})
 
-link_directories( ${QtTesting_LIBRARY_DIR} )
-
-# Source files.
 qt5_wrap_cpp(qtTestingSupportMocSrcs
   pqCoreTestUtility.h
   pqFileDialogEventPlayer.h
@@ -44,30 +35,33 @@ set(qtTestingSupportSrcs
   pqXMLEventSource.cxx
 )
 
-source_group("Generated" FILES
-  ${qtTestingSupportMocSrcs}
-)
-
-# Build and link library.
 add_library(${PROJECT_NAME}
   ${qtTestingSupportSrcs}
   ${qtTestingSupportMocSrcs}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  LINK_LIBRARIES
-  LINK_PUBLIC
+target_include_directories(${PROJECT_NAME} SYSTEM
+  PUBLIC
+  ${QtTesting_INCLUDE_DIRS}
+  ${vtkGUISupportQt_INCLUDE_DIRS}
+)
+
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   ${QtTesting_LIBRARIES}
-  LINK_PRIVATE
+  PRIVATE
+  qtExtensions
+  qtVgWidgets
   vtkGUISupportQt
   vtkRenderingCore
   ${VTK_OPENGL_RENDERING_COMPONENTS}
   vtkTestingRendering
   vtksys
-  PRIVATE_INTERFACE_TARGETS
-  qtExtensions
-  qtVgWidgets
 )
-vg_target_include_directories(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR})
 
 install_library_targets(${PROJECT_NAME})

--- a/Libraries/QtVgCommon/CMakeLists.txt
+++ b/Libraries/QtVgCommon/CMakeLists.txt
@@ -33,10 +33,17 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/vgPluginPaths.cxx"
 )
 
-add_library(${PROJECT_NAME} ${sources})
+vg_add_library(${PROJECT_NAME} ${sources})
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS qtExtensions vgCommon
+target_link_libraries(${PROJECT_NAME}Headers
+  INTERFACE
+  vgCommonHeaders
+)
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+  qtExtensions
+  vgCommon
 )
 
 install_library_targets(${PROJECT_NAME})

--- a/Libraries/QtVgWidgets/CMakeLists.txt
+++ b/Libraries/QtVgWidgets/CMakeLists.txt
@@ -56,8 +56,10 @@ add_library(${PROJECT_NAME}
   ${qtvgWidgetsSources} ${qtVgWidgetsUiSources} ${qtvgWidgetsMocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS qtExtensions vgCommon
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+  qtExtensions
+  vgCommon
 )
 
 install_library_targets(${PROJECT_NAME})

--- a/Libraries/QtVgWidgets/CMakeLists.txt
+++ b/Libraries/QtVgWidgets/CMakeLists.txt
@@ -17,21 +17,6 @@ set(qtvgWidgetsSources
     vgVideoScrubber.cxx
 )
 
-set(qtvgWidgetsMocHeaders
-    ctkRangeSlider.h
-    vgAboutAction.h
-    vgAboutDialog.h
-    vgApplication.h
-    vgFrameScrubber.h
-    vgFrameSpinBox.h
-    vgMixerDrawer.h
-    vgMixerItem.h
-    vgMixerWidget.h
-    vgTextEditDialog.h
-    vgUserManualAction.h
-    vgVideoScrubber.h
-)
-
 set(qtVgWidgetsInstallHeaders
   vgAboutAction.h
   vgAboutDialog.h
@@ -44,17 +29,7 @@ set(qtVgWidgetsInstallHeaders
   vgVideoScrubber.h
 )
 
-qt5_wrap_ui(qtVgWidgetsUiSources vgAboutDialog.ui vgTextEditDialog.ui)
-qt5_wrap_cpp(qtvgWidgetsMocSources ${qtvgWidgetsMocHeaders})
-
-source_group("Generated" FILES
-  ${qtVgWidgetsUiSources}
-  ${qtvgWidgetsMocSources}
-)
-
-add_library(${PROJECT_NAME}
-  ${qtvgWidgetsSources} ${qtVgWidgetsUiSources} ${qtvgWidgetsMocSources}
-)
+add_library(${PROJECT_NAME} ${qtvgWidgetsSources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Libraries/VgCommon/CMakeLists.txt
+++ b/Libraries/VgCommon/CMakeLists.txt
@@ -65,7 +65,7 @@ else ()
   )
   set_source_files_properties(
     "${CMAKE_CURRENT_BINARY_DIR}/vgFingerprint.cxx"
-    PROPERTIES GENERATED TRUE
+    PROPERTIES GENERATED TRUE SKIP_AUTOGEN TRUE
   )
 endif ()
 

--- a/Libraries/VgCommon/Testing/CMakeLists.txt
+++ b/Libraries/VgCommon/Testing/CMakeLists.txt
@@ -1,4 +1,3 @@
-vg_include_library_sdk_directories(qtExtensions)
 set(VGTEST_LINK_LIBRARIES qtExtensions vgCommon)
 
 vg_add_test(vgCommon-Geodesy testVgGeodesy SOURCES TestGeodesy.cxx)

--- a/Libraries/VgDataFramework/CMakeLists.txt
+++ b/Libraries/VgDataFramework/CMakeLists.txt
@@ -76,22 +76,18 @@ set(vgDataFrameworkWrapObjects
 
 qt5_wrap_cpp(vgDataFrameworkMocSources ${vgDataFrameworkMocHeaders})
 
-vg_include_library_sdk_directories(TARGET ${PROJECT_NAME} INTERFACE
-  qtExtensions
-  vgCommon
-)
-
 add_library(${PROJECT_NAME}
   ${vgDataFrameworkSources}
   ${vgDataFrameworkMocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   vvIO
-  LINK_LIBRARIES
-  LINK_PUBLIC
-  Qt5::Core Qt5::Concurrent
+  vgCommonHeaders
+  qtExtensionsHeaders
+  Qt5::Core
+  Qt5::Concurrent
 )
 
 install_library_targets(${PROJECT_NAME})

--- a/Libraries/VgDataFramework/CMakeLists.txt
+++ b/Libraries/VgDataFramework/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(vgDataFramework)
 
 set(vgDataFrameworkSources
+  vdfAbstractQuerySessionNode.cxx
   vdfDataReader.cxx
   vdfDataSource.cxx
   vdfNodeBase.cxx
@@ -15,20 +16,6 @@ set(vgDataFrameworkSources
   vdfTrackReader.cxx
   vdfTrackSource.cxx
   vdfUtil.cxx
-)
-
-set(vgDataFrameworkMocHeaders
-  vdfAbstractQuerySessionNode.h
-  vdfDataReader.h
-  vdfDataSource.h
-  vdfNodeBase.h
-  vdfNodeProxy.h
-  vdfQuerySessionNode.h
-  vdfSelector.h
-  vdfTemporalSelector.h
-  vdfTrackReader.h
-  vdfTrackReaderPrivate.h
-  vdfTrackSource.h
 )
 
 set(vgDataFrameworkInstallHeaders
@@ -74,12 +61,7 @@ set(vgDataFrameworkWrapObjects
   #vdfAbstractTrackNode CANNOT WRAP, depends on vtkVgModelView
 )
 
-qt5_wrap_cpp(vgDataFrameworkMocSources ${vgDataFrameworkMocHeaders})
-
-add_library(${PROJECT_NAME}
-  ${vgDataFrameworkSources}
-  ${vgDataFrameworkMocSources}
-)
+add_library(${PROJECT_NAME} ${vgDataFrameworkSources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Libraries/VgDataFramework/vdfAbstractQuerySessionNode.cxx
+++ b/Libraries/VgDataFramework/vdfAbstractQuerySessionNode.cxx
@@ -1,0 +1,4 @@
+// This file exists only to trigger CMake automoc to include the MOC source for
+// the vdfAbstractQuerySessionNode class, which requires that the source file
+// name exactly match the header file name. As an abstract class, the
+// "implementation" (aside from the MOC parts) can be found in the header file.

--- a/Libraries/VgDataFramework/vdfTrackReader.cxx
+++ b/Libraries/VgDataFramework/vdfTrackReader.cxx
@@ -1,11 +1,10 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include "vdfTrackReader.h"
-#include "vdfTrackReaderPrivate.h"
+#include "moc_vdfTrackReaderPrivate.cpp"
 
 #include "vdfDataSource.h"
 #include "vdfTrackSource.h"

--- a/Libraries/VgGuiFramework/CMakeLists.txt
+++ b/Libraries/VgGuiFramework/CMakeLists.txt
@@ -15,14 +15,6 @@ set(vgGuiFrameworkAMUI
   contextMenu.ui
 )
 
-set(vgGuiFrameworkUI ${vgGuiFrameworkAMUI})
-
-set(vgGuiFrameworkMocHeaders
-  vgfContextMenu.h
-  vgfItemModel.h
-  vgfNoteTreeModel.h
-)
-
 set(vgGuiFrameworkInstallHeaders
   vgfContextMenu.h
   vgfItemModel.h
@@ -39,17 +31,13 @@ set(vgGuiFrameworkWrapObjects
   vgfItemReference
 )
 
-qt5_wrap_ui(vgGuiFrameworkUiSources ${vgGuiFrameworkUI})
 qte_amc_wrap_ui(vgGuiFrameworkAmSources ActionManagerDialog
   ${vgGuiFrameworkAMUI}
 )
-qt5_wrap_cpp(vgGuiFrameworkMocSources ${vgGuiFrameworkMocHeaders})
 
 add_library(${PROJECT_NAME}
   ${vgGuiFrameworkSources}
-  ${vgGuiFrameworkUiSources}
   ${vgGuiFrameworkAmSources}
-  ${vgGuiFrameworkMocSources}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/Libraries/VgGuiFramework/CMakeLists.txt
+++ b/Libraries/VgGuiFramework/CMakeLists.txt
@@ -52,13 +52,11 @@ add_library(${PROJECT_NAME}
   ${vgGuiFrameworkMocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PRIVATE_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
   qtVgCommon
   vgCommon
   qtExtensions
-  LINK_LIBRARIES
-  LINK_PUBLIC
 )
 
 install_library_targets(${PROJECT_NAME})

--- a/Libraries/VgVideo/CMakeLists.txt
+++ b/Libraries/VgVideo/CMakeLists.txt
@@ -1,11 +1,5 @@
 project(vgVideo)
 
-vg_include_library_sdk_directories(
-  TARGET ${PROJECT_NAME} INTERFACE
-  vgCommon
-  qtVgCommon
-)
-
 set(vgVideoSources
     vgImage.cxx
     vgIStream.cxx
@@ -46,6 +40,7 @@ add_library(${PROJECT_NAME} ${vgVideoSources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
+  qtVgCommonHeaders
   vgCommonHeaders
   qtExtensionsHeaders
   Qt5::Gui

--- a/Libraries/VgVtkVideo/CMakeLists.txt
+++ b/Libraries/VgVtkVideo/CMakeLists.txt
@@ -1,21 +1,13 @@
 project(vgVtkVideo)
 
-set(vvvSources
+set(vgVtkVideoSources
   vgVideoAnimation.cxx
   vgVideoSeekRequest.cxx
   vgVideoPlayer.cxx
   vgVideoPlayerBufferedRequestor.cxx
   vgVideoPlayerRequestor.cxx
   vgVideoRequestor.cxx
-)
-
-set(vvvMocHeaders
-  vgVideoAnimation.h
-  vgVideoPlayer.h
-  vgVideoPlayerBufferedRequestor.h
-  vgVideoPlayerPrivate.h
-  vgVideoPlayerRequestor.h
-  vgVideoSourceRequestor.h
+  vgVideoSourceRequestor.cxx
 )
 
 set(vgVtkVideoInstallHeaders
@@ -31,11 +23,7 @@ include_directories(SYSTEM
   ${VTK_INCLUDE_DIRS}
 )
 
-qt5_wrap_cpp(mocSources ${vvvMocHeaders})
-
-source_group("Generated" FILES ${mocSources})
-
-add_library(${PROJECT_NAME} ${vvvSources} ${mocSources})
+add_library(${PROJECT_NAME} ${vgVtkVideoSources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Libraries/VgVtkVideo/CMakeLists.txt
+++ b/Libraries/VgVtkVideo/CMakeLists.txt
@@ -37,17 +37,15 @@ source_group("Generated" FILES ${mocSources})
 
 add_library(${PROJECT_NAME} ${vvvSources} ${mocSources})
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   qtExtensions
   vgVideo
   vtkVgCore
   vtkVgVideo
-  LINK_LIBRARIES
-  LINK_PUBLIC
   vtkRenderingCore
   ${VTK_JPEG_LIBRARIES}
-  LINK_PRIVATE
+  PRIVATE
   vgl
   vgl_algo
 )

--- a/Libraries/VgVtkVideo/vgVideoPlayer.cxx
+++ b/Libraries/VgVtkVideo/vgVideoPlayer.cxx
@@ -1,10 +1,10 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include "vgVideoPlayerPrivate.h"
+#include "moc_vgVideoPlayerPrivate.cpp"
 
 #include <QtCore>
 

--- a/Libraries/VgVtkVideo/vgVideoSourceRequestor.cxx
+++ b/Libraries/VgVtkVideo/vgVideoSourceRequestor.cxx
@@ -1,0 +1,4 @@
+// This file exists only to trigger CMake automoc to include the MOC source for
+// the vgVideoSourceRequestor class, which requires that the source file name
+// exactly match the header file name. As a purely inline class (aside from the
+// MOC parts), the implementation can be found in the header file.

--- a/Libraries/VspData/CMakeLists.txt
+++ b/Libraries/VspData/CMakeLists.txt
@@ -11,6 +11,8 @@ set(vspData_Sources
     vsSourceService.cxx
     # Data sources
     vsDataSource.cxx
+    vsDescriptorSource.cxx
+    vsTrackSource.cxx
     vsVideoSource.cxx
     vsSimpleSourceFactory.cxx
     vsSourceFactory.cxx
@@ -24,18 +26,6 @@ set(vspData_Sources
     vsLibDebug.cxx
     vsTrackInfo.cxx
     vtkVsTrackInfo.cxx
-)
-
-set(vspData_MocHeaders
-    # Live descriptors
-    vsLiveDescriptor.h
-    vsLiveDescriptorPrivate.h
-    # Data sources
-    vsDataSource.h
-    vsVideoSource.h
-    vsVideoSourcePrivate.h
-    vsTrackSource.h
-    vsDescriptorSource.h
 )
 
 set(vspDataInstallHeaders
@@ -68,12 +58,7 @@ set(vspDataInstallHeaders
   vtkVsTrackInfo.h
 )
 
-qt5_wrap_cpp(vspData_MocSources ${vspData_MocHeaders})
-
-add_library(${PROJECT_NAME}
-  ${vspData_Sources}
-  ${vspData_MocSources}
-)
+add_library(${PROJECT_NAME} ${vspData_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Libraries/VspData/CMakeLists.txt
+++ b/Libraries/VspData/CMakeLists.txt
@@ -75,8 +75,8 @@ add_library(${PROJECT_NAME}
   ${vspData_MocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   qtExtensions
   qtVgCommon
   vgVideo

--- a/Libraries/VspData/vsDescriptorSource.cxx
+++ b/Libraries/VspData/vsDescriptorSource.cxx
@@ -1,0 +1,4 @@
+// This file exists only to trigger CMake automoc to include the MOC source for
+// the vsDescriptorSource class, which requires that the source file name
+// exactly match the header file name. As a mostly-abstract class, the
+// "implementation" (aside from the MOC parts) can be found in the header file.

--- a/Libraries/VspData/vsLiveDescriptor.cxx
+++ b/Libraries/VspData/vsLiveDescriptor.cxx
@@ -1,11 +1,10 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include "vsLiveDescriptor.h"
-#include "vsLiveDescriptorPrivate.h"
+#include "moc_vsLiveDescriptorPrivate.cpp"
 
 #include <QTimer>
 

--- a/Libraries/VspData/vsTrackSource.cxx
+++ b/Libraries/VspData/vsTrackSource.cxx
@@ -1,0 +1,4 @@
+// This file exists only to trigger CMake automoc to include the MOC source for
+// the vsTrackSource class, which requires that the source file name exactly
+// match the header file name. As a mostly-abstract class, the "implementation"
+// (aside from the MOC parts) can be found in the header file.

--- a/Libraries/VspData/vsVideoSource.cxx
+++ b/Libraries/VspData/vsVideoSource.cxx
@@ -1,10 +1,10 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include "vsVideoSourcePrivate.h"
+#include "moc_vsVideoSourcePrivate.cpp"
 
 #include <qtMap.h>
 

--- a/Libraries/VspSourceUtil/CMakeLists.txt
+++ b/Libraries/VspSourceUtil/CMakeLists.txt
@@ -43,8 +43,8 @@ add_library(${PROJECT_NAME}
   ${vspSourceUtil_MocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   vspData
 )
 

--- a/Libraries/VspSourceUtil/CMakeLists.txt
+++ b/Libraries/VspSourceUtil/CMakeLists.txt
@@ -16,13 +16,6 @@ set(vspSourceUtil_Sources
     vsVideoHelper.cxx
 )
 
-set(vspSourceUtil_MocHeaders
-    vsStreamSource.h
-    vsStreamSourcePrivate.h
-    vsVideoArchive.h
-    vsVideoHelper.h
-)
-
 set(vspSourceUtilInstallHeaders
   vsAdapt.h
   vsAdaptTracks.h
@@ -36,12 +29,7 @@ set(vspSourceUtilInstallHeaders
   vsVideoHelper.h
 )
 
-qt5_wrap_cpp(vspSourceUtil_MocSources ${vspSourceUtil_MocHeaders})
-
-add_library(${PROJECT_NAME}
-  ${vspSourceUtil_Sources}
-  ${vspSourceUtil_MocSources}
-)
+add_library(${PROJECT_NAME} ${vspSourceUtil_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Libraries/VspSourceUtil/vsStreamSource.cxx
+++ b/Libraries/VspSourceUtil/vsStreamSource.cxx
@@ -1,10 +1,10 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include "vsStreamSourcePrivate.h"
+#include "moc_vsStreamSourcePrivate.cpp"
 
 #include <vgCheckArg.h>
 

--- a/Libraries/VspUserInterface/CMakeLists.txt
+++ b/Libraries/VspUserInterface/CMakeLists.txt
@@ -156,28 +156,24 @@ add_library(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-  LINK_PRIVATE
-  ${VTK_OPENGL_RENDERING_COMPONENTS}
-  vtkCommonSystem
-  vtkImagingStencil
-  vtkGUISupportQt
-)
-
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+  PUBLIC
   qtExtensions
   vtkVgCore
   vtkVgModelView
   vgVtkVideo
   vgGuiFramework
   vspData
-  PRIVATE_INTERFACE_TARGETS
+  PRIVATE
   vgCommon
   qtVgCommon
   qtVgWidgets
   vvIO
   vvWidgets
   vtkVgQtUtil
+  ${VTK_OPENGL_RENDERING_COMPONENTS}
+  vtkCommonSystem
+  vtkImagingStencil
+  vtkGUISupportQt
   ${TESTING_INTERFACES}
 # TODO: Only needed for code that should be moved out
   vtkVgSceneGraph

--- a/Libraries/VspUserInterface/CMakeLists.txt
+++ b/Libraries/VspUserInterface/CMakeLists.txt
@@ -70,46 +70,6 @@ set(vspUserInterface_AMUI
     vsp.ui
 )
 
-set(vspUserInterface_UI
-    alertEditor.ui
-    eventInfo.ui
-    trackColor.ui
-    ${vspUserInterface_AMUI}
-)
-
-set(vspUserInterface_MocHeaders
-    # Core code
-    vsApplication.h
-    vsCore.h
-    vsMainWindow.h
-    vsMainWindowPrivate.h
-    vsScene.h
-    # Supporting code
-    vsAlertEditor.h
-    vsAlertList.h
-    vsContourWidget.h
-    vsEventDataModel.h
-    vsEventInfoWidget.h
-    vsEventTreeModel.h
-    vsEventTreeSelectionModel.h
-    vsEventTreeView.h
-    vsEventTreeWidget.h
-    vsNoteTreeWidget.h
-    vsRegionList.h
-    vsTrackColorDialog.h
-    vsTrackTreeModel.h
-    vsTrackTreeSelectionModel.h
-    vsTrackTreeView.h
-    vsTrackTreeWidget.h
-# TODO: Everything below should be moved to either plugins or the application
-    # Query formulation (viqui integration)
-    vsQfDialog.h
-    vsQfVideoPlayer.h
-    vsQfVideoSource.h
-    # Built-in live descriptors - TODO: move to application?
-    vsTripwireDescriptor.h
-)
-
 set(vspUserInterface_SdkHeaders
     # Core code
     vsApplication.h
@@ -127,32 +87,13 @@ set(vspUserInterface_SdkHeaders
 
 # BEGIN build rules
 
-qt5_wrap_ui(vspUserInterface_UiSources ${vspUserInterface_UI})
 qte_amc_wrap_ui(vspUserInterface_AmSources ActionManagerDialog
   ${vspUserInterface_AMUI}
-)
-qt5_wrap_cpp(vspUserInterface_MocSources ${vspUserInterface_MocHeaders})
-
-source_group("User Interface" FILES
-  ${vspUserInterface_UI}
-)
-
-source_group("Generated" FILES
-  ${vspUserInterface_UiSources}
-  ${vspUserInterface_AmSources}
-  ${vspUserInterface_MocSources}
-)
-
-set_source_files_properties(${vspUserInterface_Sources}
-  PROPERTIES OBJECT_DEPENDS
-  "${vspUserInterface_UiSources};${vspUserInterface_AmSources}"
 )
 
 add_library(${PROJECT_NAME}
   ${vspUserInterface_Sources}
-  ${vspUserInterface_UiSources}
   ${vspUserInterface_AmSources}
-  ${vspUserInterface_MocSources}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/Libraries/VtkVgCore/CMakeLists.txt
+++ b/Libraries/VtkVgCore/CMakeLists.txt
@@ -208,14 +208,14 @@ vg_vtk_module(${PROJECT_NAME}
 )
 
 # Build and link library.
+add_library(${PROJECT_NAME}Headers INTERFACE)
 vtk_module_library(${PROJECT_NAME} ${vtkVgCoreSrcs})
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+  ${PROJECT_NAME}Headers
   vgCommon
-  LINK_LIBRARIES
-  LINK_PUBLIC
-  LINK_PRIVATE
+  PRIVATE
   vgl
   vgl_algo
   vnl

--- a/Libraries/VtkVgCore/Testing/Cxx/CMakeLists.txt
+++ b/Libraries/VtkVgCore/Testing/Cxx/CMakeLists.txt
@@ -1,8 +1,4 @@
-vg_include_library_sdk_directories(qtExtensions)
-
-set(VGTEST_LINK_LIBRARIES qtExtensions)
-
-include_directories(${vtkVgCore_SOURCE_DIR})
+set(VGTEST_LINK_LIBRARIES qtExtensions vtkVgCoreHeaders)
 
 vg_add_test(vtkVgCore-Instance testVtkVgInstance
             SOURCES TestInstance.cxx LINK_LIBRARIES vtkVgCore

--- a/Libraries/VtkVgIO/CMakeLists.txt
+++ b/Libraries/VtkVgIO/CMakeLists.txt
@@ -48,12 +48,11 @@ vtk_module_library(${PROJECT_NAME}
   ${vtkVgIOSrcs}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   vgCommon
   vtkVgCore
-  LINK_LIBRARIES
-  LINK_PRIVATE
+  PRIVATE
   ${GDAL_LIBRARY}
   ${Boost_LIBRARIES}
 )

--- a/Libraries/VtkVgModelView/CMakeLists.txt
+++ b/Libraries/VtkVgModelView/CMakeLists.txt
@@ -109,8 +109,8 @@ vg_vtk_module(${PROJECT_NAME}
 # Build and link library.
 vtk_module_library(${PROJECT_NAME} ${vtkVgModelViewSrcs})
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   vtkVgCore
 )
 

--- a/Libraries/VtkVgQtSceneUtil/CMakeLists.txt
+++ b/Libraries/VtkVgQtSceneUtil/CMakeLists.txt
@@ -17,12 +17,11 @@ set(vtkVgQtSceneUtilInstallHeaders
 # Build and link library.
 add_library(${PROJECT_NAME} ${vtkVgQtSceneUtilSrcs})
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   vtkVgSceneGraph
   qtExtensions
-  LINK_LIBRARIES
-  LINK_PRIVATE
+  PRIVATE
   vil_io
   vnl_io
   vgl_algo

--- a/Libraries/VtkVgQtUtil/CMakeLists.txt
+++ b/Libraries/VtkVgQtUtil/CMakeLists.txt
@@ -4,10 +4,6 @@ include_directories(SYSTEM
   ${VTK_INCLUDE_DIRS}
 )
 
-vg_include_library_sdk_directories(
-  vtkVgCore
-)
-
 set(vtkVgQtUtilSources
   vtkVgQtUtil.cxx
 )
@@ -26,6 +22,11 @@ vg_vtk_module(${PROJECT_NAME}
 # Build and link library.
 vtk_module_library(${PROJECT_NAME}
   ${vtkVgQtUtilSources}
+)
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+  vtkVgCoreHeaders
 )
 
 install_library_targets(${PROJECT_NAME})

--- a/Libraries/VtkVgQtWidgets/CMakeLists.txt
+++ b/Libraries/VtkVgQtWidgets/CMakeLists.txt
@@ -28,18 +28,16 @@ add_library(${PROJECT_NAME}
   ${vtkVgQtWidgetsMocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PRIVATE_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+  vtkInteractionWidgets
+  PRIVATE
   qtVgCommon
   qtExtensions
   vtkVgModelView
   vtkVgQtUtil
-  LINK_LIBRARIES
-  LINK_PRIVATE
   ${VTK_OPENGL_RENDERING_COMPONENTS}
   vtkGUISupportQt
-  LINK_PUBLIC
-  vtkInteractionWidgets
 )
 
 install_library_targets(${PROJECT_NAME})

--- a/Libraries/VtkVgQtWidgets/CMakeLists.txt
+++ b/Libraries/VtkVgQtWidgets/CMakeLists.txt
@@ -13,20 +13,11 @@ set(vtkVgQtWidgetsSources
   vtkVgRegionWidget.cxx
 )
 
-set(vtkVgQtWidgetsMocHeaders
-  vtkVgRegionWidget.h
-)
-
 set(vtkVgQtWidgetsInstallHeaders
   vtkVgRegionWidget.h
 )
 
-qt5_wrap_cpp(vtkVgQtWidgetsMocSources ${vtkVgQtWidgetsMocHeaders})
-
-add_library(${PROJECT_NAME}
-  ${vtkVgQtWidgetsSources}
-  ${vtkVgQtWidgetsMocSources}
-)
+add_library(${PROJECT_NAME} ${vtkVgQtWidgetsSources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Libraries/VtkVgSceneGraph/CMakeLists.txt
+++ b/Libraries/VtkVgSceneGraph/CMakeLists.txt
@@ -61,8 +61,8 @@ vg_vtk_module(${PROJECT_NAME}
 # Build and link library.
 vtk_module_library(${PROJECT_NAME} ${vtkVgSceneGraphSrcs})
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   vtkVgModelView
 )
 

--- a/Libraries/VtkVgVideo/CMakeLists.txt
+++ b/Libraries/VtkVgVideo/CMakeLists.txt
@@ -32,13 +32,11 @@ vtk_module_library(${PROJECT_NAME}
   ${vtkVgVideoMocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   vtkVgCore
-  PRIVATE_INTERFACE_TARGETS
+  PRIVATE
   vgVideo
-  LINK_LIBRARIES
-  LINK_PRIVATE
   vgl_algo
   Qt5::Core
 )

--- a/Libraries/VtkVwCore/CMakeLists.txt
+++ b/Libraries/VtkVwCore/CMakeLists.txt
@@ -30,13 +30,11 @@ vtk_module_library(${PROJECT_NAME}
   ${vtkVwCoreMocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PRIVATE_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
   vgVideo
   vtkVgCore
   vvIO
-  LINK_LIBRARIES
-  LINK_PRIVATE
   ${LIBJSON_LIBRARY}
   ${PYTHON_LIBRARIES}
 )

--- a/Libraries/VtkVwCore/CMakeLists.txt
+++ b/Libraries/VtkVwCore/CMakeLists.txt
@@ -19,16 +19,11 @@ set(vtkVwCoreInstallHeaders
   vtkVwVideo.h
 )
 
-qt5_wrap_cpp(vtkVwCoreMocSources ${vtkVwCoreMocHeaders})
-
 vg_vtk_module(${PROJECT_NAME}
   DEPENDS vtkCommonCore
   EXCLUDE_FROM_WRAP_HIERARCHY
 )
-vtk_module_library(${PROJECT_NAME}
-  ${vtkVwCoreSources}
-  ${vtkVwCoreMocSources}
-)
+vtk_module_library(${PROJECT_NAME} ${vtkVwCoreSources})
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE

--- a/Libraries/VvData/CMakeLists.txt
+++ b/Libraries/VvData/CMakeLists.txt
@@ -1,6 +1,4 @@
-vg_include_library_sdk_directories(
-  TARGET vvData INTERFACE vgCommon
-)
+project(vvData)
 
 set(vvData_InstallHeaders
   vvDescriptor.h
@@ -11,5 +9,13 @@ set(vvData_InstallHeaders
   vvUserData.h
 )
 
-install_headers(${vvData_InstallHeaders} TARGET vvData
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_link_libraries(${PROJECT_NAME}
+  INTERFACE
+  vgCommonHeaders
+)
+
+install_library_targets(${PROJECT_NAME})
+install_headers(${vvData_InstallHeaders} TARGET ${PROJECT_NAME}
                 DESTINATION include/VvData)

--- a/Libraries/VvIO/CMakeLists.txt
+++ b/Libraries/VvIO/CMakeLists.txt
@@ -76,16 +76,12 @@ qt5_wrap_cpp(vvIO_MocSources ${vvIO_MocHeaders})
 
 add_library(${PROJECT_NAME} ${vvIO_Sources} ${vvIO_MocSources})
 
-vg_include_library_sdk_directories(
-  TARGET ${PROJECT_NAME} INTERFACE vvData
-)
-
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
-  qtExtensions
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+  vvData
   qtVgCommon
-  LINK_LIBRARIES
-  LINK_PRIVATE
+  qtExtensions
+  PRIVATE
   ${Boost_LIBRARIES}
   kml
 )

--- a/Libraries/VvIO/CMakeLists.txt
+++ b/Libraries/VvIO/CMakeLists.txt
@@ -19,6 +19,7 @@ set(vvIO_Sources
   vvXmlUtil.cxx
   # Query Server Interface
   vvQueryInstance.cxx
+  vvQueryNotifier.cxx
   vvQueryService.cxx
   vvQuerySession.cxx
   # Utility Functions
@@ -28,12 +29,6 @@ set(vvIO_Sources
   vvKmlLine.cxx
   vvMakeId.cxx
   vvUtil.cxx
-)
-
-set(vvIO_MocHeaders
-  # Query Server Interface
-  vvQueryNotifier.h
-  vvQuerySession.h
 )
 
 set(vvIOInstallHeaders
@@ -72,9 +67,7 @@ set(vvIOWrapObjects
   vvTrackId
 )
 
-qt5_wrap_cpp(vvIO_MocSources ${vvIO_MocHeaders})
-
-add_library(${PROJECT_NAME} ${vvIO_Sources} ${vvIO_MocSources})
+add_library(${PROJECT_NAME} ${vvIO_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Libraries/VvIO/vvQueryNotifier.cxx
+++ b/Libraries/VvIO/vvQueryNotifier.cxx
@@ -1,0 +1,4 @@
+// This file exists only to trigger CMake automoc to include the MOC source for
+// the vvQueryNotifier class, which requires that the source file name exactly
+// match the header file name. As a purely inline class (aside from the MOC
+// parts), the implementation can be found in the header file.

--- a/Libraries/VvVidtk/CMakeLists.txt
+++ b/Libraries/VvVidtk/CMakeLists.txt
@@ -5,10 +5,6 @@ include_directories(
   ${VIDTK_INCLUDE_DIRS}
 )
 
-vg_include_library_sdk_directories(
-  TARGET ${PROJECT_NAME} INTERFACE vvData
-)
-
 set(vvVidtkInstallHeaders
   vvAdaptVidtk.h
 )
@@ -16,8 +12,12 @@ set(vvVidtkInstallHeaders
 add_library(${PROJECT_NAME} vvAdaptVidtk.cxx)
 
 target_link_libraries(${PROJECT_NAME}
-  PUBLIC Qt5::Core
-  PRIVATE vidtk_tracking)
+  PUBLIC
+  Qt5::Core
+  PRIVATE
+  vvData
+  vidtk_tracking
+)
 
 install_library_targets(${PROJECT_NAME})
 install_headers(${vvVidtkInstallHeaders} TARGET ${PROJECT_NAME}

--- a/Libraries/VvVtkWidgets/CMakeLists.txt
+++ b/Libraries/VvVtkWidgets/CMakeLists.txt
@@ -13,17 +13,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-set(vvVtkWidgetsMocHeaders
-  vvAbstractSimilarityQueryDialog.h
-  vvClipVideoRepresentation.h
-  vvGenerateReportDialog.h
-  vvQueryVideoPlayer.h
-  vvReportWriter.h
-  vvVideoPlayer.h
-  vvVideoPlayerModel.h
-  vvVideoQueryDialog.h
-)
-
 set(vvVtkWidgetsSources
   vvAbstractSimilarityQueryDialog.cxx
   vvClipVideoRepresentation.cxx
@@ -36,12 +25,6 @@ set(vvVtkWidgetsSources
   vvVideoPlayerModel.cxx
   vvVideoQueryDialog.cxx
   vvVideoQueryDialogPrivate.cxx
-)
-
-set(vvVtkWidgetsUiFiles
-  generateReport.ui
-  videoQuery.ui
-  videoView.ui
 )
 
 set(vvVtkWidgetsInstallHeaders
@@ -80,20 +63,14 @@ if (${VISGUI_ENABLE_KWPPT})
     vvPowerPointTrackSlideGenerator.cxx
     vvPowerPointWriter.cxx
   )
-  list(APPEND vvVtkWidgetsMocHeaders
-    vvGeneratePowerPointDialog.h
-    vvPowerPointWriter.h
-  )
-  list(APPEND vvVtkWidgetsInstallHeaders
+
+ list(APPEND vvVtkWidgetsInstallHeaders
     vvGeneratePowerPointDialog.h
     vvPowerPointEventSlideGenerator.h
     vvPowerPointExtensionInterface.h
     vvPowerPointSlideGenerator.h
     vvPowerPointTrackSlideGenerator.h
     vvPowerPointWriter.h
-  )
-  list(APPEND vvVtkWidgetsUiFiles
-    generatePowerPoint.ui
   )
 endif()
 
@@ -103,14 +80,7 @@ endif()
 
 # BEGIN build rules
 
-qt5_wrap_cpp(mocSources ${vvVtkWidgetsMocHeaders})
-qt5_wrap_ui(uiSources ${vvVtkWidgetsUiFiles})
-
-add_library(${PROJECT_NAME}
-  ${vvVtkWidgetsSources}
-  ${mocSources}
-  ${uiSources}
-)
+add_library(${PROJECT_NAME} ${vvVtkWidgetsSources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Libraries/VvVtkWidgets/CMakeLists.txt
+++ b/Libraries/VvVtkWidgets/CMakeLists.txt
@@ -112,20 +112,18 @@ add_library(${PROJECT_NAME}
   ${uiSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   vvWidgets
   qtVgWidgets
   qtVgCommon
   qtExtensions
   vgVtkVideo
   vtkVgQtWidgets
-  PRIVATE_INTERFACE_TARGETS
+  PRIVATE
   vtkVgModelView
   vtkVgSceneGraph
   vtkVgQtUtil
-  LINK_LIBRARIES
-  LINK_PRIVATE
   ${VTK_OPENGL_RENDERING_COMPONENTS}
   vtkCommonSystem
   vtkGUISupportQt

--- a/Libraries/VvWidgets/CMakeLists.txt
+++ b/Libraries/VvWidgets/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(
 )
 
 set(vvWidgets_Sources
+  vvAbstractQueryServerChooser.cxx
   vvCustomQueryServerChooser.cxx
   vvDescriptorInfoDialog.cxx
   vvDescriptorInfoTree.cxx
@@ -22,31 +23,6 @@ set(vvWidgets_Sources
   vvScoreGradientWidget.cxx
   vvTrackInfoDialog.cxx
   vvTrackInfoWidget.cxx
-)
-
-set(vvWidgets_MocHeaders
-  vvAbstractQueryServerChooser.h
-  vvCustomQueryServerChooser.h
-  vvDescriptorInfoDialog.h
-  vvDescriptorInfoTree.h
-  vvDescriptorInfoWidget.h
-  vvDescriptorStyleDelegate.h
-  vvQueryInfoLabel.h
-  vvQueryServerDialog.h
-  vvScoreGradientStopTree.h
-  vvScoreGradientWidget.h
-  vvTrackInfoDialog.h
-  vvTrackInfoWidget.h
-)
-
-set(vvWidgets_UiFiles
-  vvCustomQueryServerChooser.ui
-  vvDescriptorInfoDialog.ui
-  vvDescriptorInfoWidget.ui
-  vvQueryServerDialog.ui
-  vvScoreGradientWidget.ui
-  vvTrackInfoDialog.ui
-  vvTrackInfoWidget.ui
 )
 
 set(vvWidgetsInstallHeaders
@@ -66,14 +42,7 @@ set(vvWidgetsInstallHeaders
   vvTrackInfoWidget.h
 )
 
-qt5_wrap_cpp(vvWidgets_MocSources ${vvWidgets_MocHeaders})
-qt5_wrap_ui(vvWidgets_UiSources ${vvWidgets_UiFiles})
-
-add_library(${PROJECT_NAME}
-  ${vvWidgets_Sources}
-  ${vvWidgets_MocSources}
-  ${vvWidgets_UiSources}
-)
+add_library(${PROJECT_NAME} ${vvWidgets_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Libraries/VvWidgets/CMakeLists.txt
+++ b/Libraries/VvWidgets/CMakeLists.txt
@@ -75,8 +75,8 @@ add_library(${PROJECT_NAME}
   ${vvWidgets_UiSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   vvIO
   qtVgCommon
   qtExtensions

--- a/Libraries/VvWidgets/Testing/CMakeLists.txt
+++ b/Libraries/VvWidgets/Testing/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(VGTEST_LINK_LIBRARIES vvWidgets vvIO qtExtensions)
 
-vg_add_test(testQueryInfoLabel INTERACTIVE
-  SOURCES TestQueryInfoLabel.cxx
-  RESOURCES ${CMAKE_SOURCE_DIR}/Icons/stdbutton.qrc
+vg_add_test(testQueryInfoLabel INTERACTIVE SOURCES
+  TestQueryInfoLabel.cxx
+  ${CMAKE_SOURCE_DIR}/Icons/stdbutton.qrc
 )
 
-vg_add_test(testScoreGradientWidget INTERACTIVE
-  SOURCES TestScoreGradientWidget.cxx
-  RESOURCES ${CMAKE_SOURCE_DIR}/Icons/vvwidgets.qrc
+vg_add_test(testScoreGradientWidget INTERACTIVE SOURCES
+  TestScoreGradientWidget.cxx
+  ${CMAKE_SOURCE_DIR}/Icons/vvwidgets.qrc
 )

--- a/Libraries/VvWidgets/vvAbstractQueryServerChooser.cxx
+++ b/Libraries/VvWidgets/vvAbstractQueryServerChooser.cxx
@@ -1,0 +1,4 @@
+// This file exists only to trigger CMake automoc to include the MOC source for
+// the vvAbstractQueryServerChooser class, which requires that the source file
+// name exactly match the header file name. As an abstract class, the
+// "implementation" (aside from the MOC parts) can be found in the header file.

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/CMakeLists.txt
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(vdfTrackOracleArchiveSource)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 if(TARGET kwiver::track_oracle)
   include_directories(SYSTEM ${KWIVER_INCLUDE_DIRS})
   add_definitions(-DKWIVER_TRACK_ORACLE)
@@ -17,18 +12,7 @@ set(vdfTrackOracleArchiveSource_Sources
   vdfTrackOracleTrackArchiveSource.cxx
 )
 
-set(vdfTrackOracleArchiveSource_MocHeaders
-  vdfTrackOracleArchiveSourcePlugin.h
-  vdfTrackOracleTrackArchiveSource.h
-)
-
-qt5_wrap_cpp(vdfTrackOracleArchiveSource_MocSources
-             ${vdfTrackOracleArchiveSource_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vdfTrackOracleArchiveSource_Sources}
-  ${vdfTrackOracleArchiveSource_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vdfTrackOracleArchiveSource_Sources})
 
 if(TARGET kwiver::track_oracle)
   target_link_libraries(${PROJECT_NAME}

--- a/Plugins/VdfDataSources/TrackOracleArchiveSource/CMakeLists.txt
+++ b/Plugins/VdfDataSources/TrackOracleArchiveSource/CMakeLists.txt
@@ -4,7 +4,6 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
-vg_include_library_sdk_directories(vgDataFramework)
 
 if(TARGET kwiver::track_oracle)
   include_directories(SYSTEM ${KWIVER_INCLUDE_DIRS})

--- a/Plugins/VspSourceService/FakeStreamSourceFactory/CMakeLists.txt
+++ b/Plugins/VspSourceService/FakeStreamSourceFactory/CMakeLists.txt
@@ -4,7 +4,6 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
-vg_include_library_sdk_directories(vspSourceUtil)
 
 set(vsFakeStreamSourceFactory_Sources
   vsFakeStreamControl.cxx

--- a/Plugins/VspSourceService/FakeStreamSourceFactory/CMakeLists.txt
+++ b/Plugins/VspSourceService/FakeStreamSourceFactory/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(vsFakeStreamSourceFactory)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsFakeStreamSourceFactory_Sources
   vsFakeStreamControl.cxx
   vsFakeStreamFactory.cxx
@@ -12,28 +7,7 @@ set(vsFakeStreamSourceFactory_Sources
   vsFakeStreamSource.cxx
 )
 
-set(vsFakeStreamSourceFactory_MocHeaders
-  vsFakeStreamControl.h
-  vsFakeStreamSourceFactoryPlugin.h
-  vsFakeStreamSource.h
-  vsFakeStreamSourcePrivate.h
-)
-
-set(vsFakeStreamSourceFactory_UI
-  fakeStreamControl.ui
-)
-
-qt5_wrap_cpp(vsFakeStreamSourceFactory_MocSources
-             ${vsFakeStreamSourceFactory_MocHeaders})
-
-qt5_wrap_ui(vsFakeStreamSourceFactory_UiSources
-            ${vsFakeStreamSourceFactory_UI})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsFakeStreamSourceFactory_Sources}
-  ${vsFakeStreamSourceFactory_MocSources}
-  ${vsFakeStreamSourceFactory_UiSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsFakeStreamSourceFactory_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vspSourceUtil

--- a/Plugins/VspSourceService/FakeStreamSourceFactory/vsFakeStreamSource.cxx
+++ b/Plugins/VspSourceService/FakeStreamSourceFactory/vsFakeStreamSource.cxx
@@ -1,11 +1,10 @@
 /*ckwg +5
- * Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include "vsFakeStreamSource.h"
-#include "vsFakeStreamSourcePrivate.h"
+#include "moc_vsFakeStreamSourcePrivate.cpp"
 
 #include <QDebug>
 #include <QDir>

--- a/Plugins/VspSourceService/KstArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/KstArchiveSource/CMakeLists.txt
@@ -1,26 +1,11 @@
 project(vsKstArchiveSource)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsKstArchiveSource_Sources
   vsKstArchiveSourcePlugin.cxx
   vsKstDescriptorArchiveSource.cxx
 )
 
-set(vsKstArchiveSource_MocHeaders
-  vsKstArchiveSourcePlugin.h
-  vsKstDescriptorArchiveSource.h
-)
-
-qt5_wrap_cpp(vsKstArchiveSource_MocSources ${vsKstArchiveSource_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsKstArchiveSource_Sources}
-  ${vsKstArchiveSource_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsKstArchiveSource_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vspSourceUtil

--- a/Plugins/VspSourceService/KstArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/KstArchiveSource/CMakeLists.txt
@@ -4,7 +4,6 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
-vg_include_library_sdk_directories(vspSourceUtil)
 
 set(vsKstArchiveSource_Sources
   vsKstArchiveSourcePlugin.cxx

--- a/Plugins/VspSourceService/Kw18ArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/Kw18ArchiveSource/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(vsKw18ArchiveSource)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 include_directories(SYSTEM
   ${Boost_INCLUDE_DIRS}
   ${VIDTK_INCLUDE_DIRS}
@@ -15,17 +10,7 @@ set(vsKw18ArchiveSource_Sources
   vsKw18TrackArchiveSource.cxx
 )
 
-set(vsKw18ArchiveSource_MocHeaders
-  vsKw18ArchiveSourcePlugin.h
-  vsKw18TrackArchiveSource.h
-)
-
-qt5_wrap_cpp(vsKw18ArchiveSource_MocSources ${vsKw18ArchiveSource_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsKw18ArchiveSource_Sources}
-  ${vsKw18ArchiveSource_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsKw18ArchiveSource_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vvVidtk

--- a/Plugins/VspSourceService/Kw18ArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/Kw18ArchiveSource/CMakeLists.txt
@@ -4,10 +4,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
-vg_include_library_sdk_directories(
-  vvVidtk
-  vspSourceUtil
-)
+
 include_directories(SYSTEM
   ${Boost_INCLUDE_DIRS}
   ${VIDTK_INCLUDE_DIRS}

--- a/Plugins/VspSourceService/KwaArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/KwaArchiveSource/CMakeLists.txt
@@ -4,7 +4,6 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
-vg_include_library_sdk_directories(vspSourceUtil)
 
 set(vsKwaArchiveSource_Sources
   vsKwaArchiveSourcePlugin.cxx

--- a/Plugins/VspSourceService/KwaArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/KwaArchiveSource/CMakeLists.txt
@@ -1,26 +1,11 @@
 project(vsKwaArchiveSource)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsKwaArchiveSource_Sources
   vsKwaArchiveSourcePlugin.cxx
   vsKwaVideoArchiveSource.cxx
 )
 
-set(vsKwaArchiveSource_MocHeaders
-  vsKwaArchiveSourcePlugin.h
-  vsKwaVideoArchiveSource.h
-)
-
-qt5_wrap_cpp(vsKwaArchiveSource_MocSources ${vsKwaArchiveSource_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsKwaArchiveSource_Sources}
-  ${vsKwaArchiveSource_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsKwaArchiveSource_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vspSourceUtil

--- a/Plugins/VspSourceService/PvoArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/PvoArchiveSource/CMakeLists.txt
@@ -1,26 +1,11 @@
 project(vsPvoArchiveSource)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsPvoArchiveSource_Sources
   vsPvoArchiveSourcePlugin.cxx
   vsPvoDescriptorArchiveSource.cxx
 )
 
-set(vsPvoArchiveSource_MocHeaders
-  vsPvoArchiveSourcePlugin.h
-  vsPvoDescriptorArchiveSource.h
-)
-
-qt5_wrap_cpp(vsPvoArchiveSource_MocSources ${vsPvoArchiveSource_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsPvoArchiveSource_Sources}
-  ${vsPvoArchiveSource_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsPvoArchiveSource_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vspSourceUtil

--- a/Plugins/VspSourceService/PvoArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/PvoArchiveSource/CMakeLists.txt
@@ -4,7 +4,6 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
-vg_include_library_sdk_directories(vspSourceUtil)
 
 set(vsPvoArchiveSource_Sources
   vsPvoArchiveSourcePlugin.cxx

--- a/Plugins/VspSourceService/RandomAlertDescriptor/CMakeLists.txt
+++ b/Plugins/VspSourceService/RandomAlertDescriptor/CMakeLists.txt
@@ -1,28 +1,12 @@
 project(vsRandomAlertDescriptor)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsRandomAlertDescriptor_Sources
   vsRandomAlertDescriptor.cxx
   vsRandomAlertDescriptorPlugin.cxx
   vsRandomAlertFactory.cxx
 )
 
-set(vsRandomAlertDescriptor_MocHeaders
-  vsRandomAlertDescriptor.h
-  vsRandomAlertDescriptorPlugin.h
-)
-
-qt5_wrap_cpp(vsRandomAlertDescriptor_MocSources
-             ${vsRandomAlertDescriptor_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsRandomAlertDescriptor_Sources}
-  ${vsRandomAlertDescriptor_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsRandomAlertDescriptor_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vspSourceUtil

--- a/Plugins/VspSourceService/RandomAlertDescriptor/CMakeLists.txt
+++ b/Plugins/VspSourceService/RandomAlertDescriptor/CMakeLists.txt
@@ -4,7 +4,6 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
-vg_include_library_sdk_directories(vspSourceUtil)
 
 set(vsRandomAlertDescriptor_Sources
   vsRandomAlertDescriptor.cxx

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(vsTrackOracleArchiveSource)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 if(TARGET kwiver::track_oracle)
   include_directories(SYSTEM ${KWIVER_INCLUDE_DIRS})
   add_definitions(-DKWIVER_TRACK_ORACLE)
@@ -18,19 +13,7 @@ set(vsTrackOracleArchiveSource_Sources
   vsTrackOracleTrackArchiveSource.cxx
 )
 
-set(vsTrackOracleArchiveSource_MocHeaders
-  vsTrackOracleArchiveSourcePlugin.h
-  vsTrackOracleDescriptorArchiveSource.h
-  vsTrackOracleTrackArchiveSource.h
-)
-
-qt5_wrap_cpp(vsTrackOracleArchiveSource_MocSources
-             ${vsTrackOracleArchiveSource_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsTrackOracleArchiveSource_Sources}
-  ${vsTrackOracleArchiveSource_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsTrackOracleArchiveSource_Sources})
 
 if (TARGET kwiver::track_oracle)
   target_link_libraries(${PROJECT_NAME}

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/CMakeLists.txt
@@ -4,7 +4,6 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
-vg_include_library_sdk_directories(vspSourceUtil)
 
 if(TARGET kwiver::track_oracle)
   include_directories(SYSTEM ${KWIVER_INCLUDE_DIRS})

--- a/Plugins/VspSourceService/ViperArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/ViperArchiveSource/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
 )
-vg_include_library_sdk_directories(vspSourceUtil)
+
 include_directories(SYSTEM
   ${VIDTK_INCLUDE_DIRS}
 )

--- a/Plugins/VspSourceService/ViperArchiveSource/CMakeLists.txt
+++ b/Plugins/VspSourceService/ViperArchiveSource/CMakeLists.txt
@@ -1,10 +1,5 @@
 project(vsViperArchiveSource)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 include_directories(SYSTEM
   ${VIDTK_INCLUDE_DIRS}
 )
@@ -16,27 +11,7 @@ set(vsViperArchiveSource_Sources
   vsViperDebug.cxx
 )
 
-set(vsViperArchiveSource_MocHeaders
-  vsViperArchiveImportOptionsDialog.h
-  vsViperArchiveSourcePlugin.h
-  vsViperArchiveSource.h
-  vsViperArchiveSourcePrivate.h
-)
-
-set(vsViperArchiveSource_UI
-  viperOptions.ui
-)
-
-qt5_wrap_cpp(vsViperArchiveSource_MocSources
-             ${vsViperArchiveSource_MocHeaders})
-
-qt5_wrap_ui(vsViperArchiveSource_UiSources ${vsViperArchiveSource_UI})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsViperArchiveSource_Sources}
-  ${vsViperArchiveSource_MocSources}
-  ${vsViperArchiveSource_UiSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsViperArchiveSource_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   track_xgtf

--- a/Plugins/VspUiExtensions/ContextViewer/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/ContextViewer/CMakeLists.txt
@@ -4,29 +4,12 @@ include_directories(SYSTEM
   ${VTK_INCLUDE_DIRS}
 )
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsContextViewerPlugin_Sources
   vsContextViewer.cxx
   vsContextViewerPlugin.cxx
 )
 
-set(vsContextViewerPlugin_MocHeaders
-  vsContextViewer.h
-  vsContextViewerPlugin.h
-)
-
-qt5_wrap_cpp(vsContextViewerPlugin_MocSources
-  ${vsContextViewerPlugin_MocHeaders}
-)
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsContextViewerPlugin_Sources}
-  ${vsContextViewerPlugin_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsContextViewerPlugin_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vspUserInterface

--- a/Plugins/VspUiExtensions/ContextViewer/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/ContextViewer/CMakeLists.txt
@@ -9,14 +9,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-vg_include_library_sdk_directories(
-  vspUserInterface
-  vtkVgSceneGraph
-  vtkVgQtUtil
-  vtkVgQtSceneUtil
-  QtVgCommon
-)
-
 set(vsContextViewerPlugin_Sources
   vsContextViewer.cxx
   vsContextViewerPlugin.cxx

--- a/Plugins/VspUiExtensions/EventCreationTools/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/EventCreationTools/CMakeLists.txt
@@ -9,8 +9,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-vg_include_library_sdk_directories(vspUserInterface)
-
 set(vsEventCreationTools_Sources
   vsEventCreationToolsInterface.cxx
   vsEventCreationToolsPlugin.cxx

--- a/Plugins/VspUiExtensions/EventCreationTools/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/EventCreationTools/CMakeLists.txt
@@ -4,35 +4,17 @@ include_directories(SYSTEM
   ${VTK_INCLUDE_DIRS}
 )
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsEventCreationTools_Sources
   vsEventCreationToolsInterface.cxx
   vsEventCreationToolsPlugin.cxx
 )
 
-set(vsEventCreationTools_MocHeaders
-  vsEventCreationToolsInterface.h
-  vsEventCreationToolsPlugin.h
-)
-
-set(vsEventCreationTools_Resources
+set(vsEventCreationTools_ResSources
   icons.qrc
-)
-
-qt5_wrap_cpp(vsEventCreationTools_MocSources
-  ${vsEventCreationTools_MocHeaders}
-)
-qt5_add_resources(vsEventCreationTools_ResSources
-  ${vsEventCreationTools_Resources}
 )
 
 vg_add_qt_plugin(${PROJECT_NAME}
   ${vsEventCreationTools_Sources}
-  ${vsEventCreationTools_MocSources}
   ${vsEventCreationTools_ResSources}
 )
 

--- a/Plugins/VspUiExtensions/PowerPointGenerator/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/PowerPointGenerator/CMakeLists.txt
@@ -9,9 +9,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-# Need this as a directory include so that moc can find the plugin interface
-vg_include_library_sdk_directories(vspUserInterface)
-
 set(vsPowerPointGeneratorExtension_Sources
   vsPowerPointGenerator.cxx
   vsPowerPointGeneratorInterface.cxx
@@ -31,8 +28,7 @@ vg_add_qt_plugin(${PROJECT_NAME}
   ${vsPowerPointGeneratorExtension_MocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PRIVATE_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
   vgVtkVideo
   vspData
   vspUserInterface

--- a/Plugins/VspUiExtensions/PowerPointGenerator/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/PowerPointGenerator/CMakeLists.txt
@@ -4,29 +4,13 @@ include_directories(SYSTEM
   ${KML_INCLUDE_DIRS}
 )
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsPowerPointGeneratorExtension_Sources
   vsPowerPointGenerator.cxx
   vsPowerPointGeneratorInterface.cxx
   vsPowerPointGeneratorPlugin.cxx
 )
 
-set(vsPowerPointGeneratorExtension_MocHeaders
-  vsPowerPointGeneratorInterface.h
-  vsPowerPointGeneratorPlugin.h
-)
-
-qt5_wrap_cpp(vsPowerPointGeneratorExtension_MocSources
-             ${vsPowerPointGeneratorExtension_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsPowerPointGeneratorExtension_Sources}
-  ${vsPowerPointGeneratorExtension_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsPowerPointGeneratorExtension_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vgVtkVideo

--- a/Plugins/VspUiExtensions/ReportGenerator/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/ReportGenerator/CMakeLists.txt
@@ -4,11 +4,6 @@ include_directories(SYSTEM
   ${KML_INCLUDE_DIRS}
 )
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 if(VSPUI_ENABLE_REPORT_GENERATOR)
   add_definitions(-DENABLE_REPORT_GENERATION)
 endif()
@@ -28,18 +23,7 @@ if(VSPUI_ENABLE_REPORT_GENERATOR)
   )
 endif()
 
-set(vsReportGeneratorExtension_MocHeaders
-  vsReportGeneratorInterface.h
-  vsReportGeneratorPlugin.h
-)
-
-qt5_wrap_cpp(vsReportGeneratorExtension_MocSources
-             ${vsReportGeneratorExtension_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsReportGeneratorExtension_Sources}
-  ${vsReportGeneratorExtension_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsReportGeneratorExtension_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vspData

--- a/Plugins/VspUiExtensions/ReportGenerator/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/ReportGenerator/CMakeLists.txt
@@ -9,9 +9,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-# Need this as a directory include so that moc can find the plugin interface
-vg_include_library_sdk_directories(vspUserInterface)
-
 if(VSPUI_ENABLE_REPORT_GENERATOR)
   add_definitions(-DENABLE_REPORT_GENERATION)
 endif()
@@ -44,8 +41,7 @@ vg_add_qt_plugin(${PROJECT_NAME}
   ${vsReportGeneratorExtension_MocSources}
 )
 
-vg_add_dependencies(${PROJECT_NAME}
-  PRIVATE_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
   vspData
   vspUserInterface
 )

--- a/Plugins/VspUiExtensions/Ruler/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/Ruler/CMakeLists.txt
@@ -9,13 +9,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-set(vsRuler_SdkTargets
-  vspUserInterface
-  vtkVgQtUtil
-)
-
-vg_include_library_sdk_directories(${vsRuler_SdkTargets})
-
 set(vsRuler_Sources
   vsLineWidget.cxx
   vsRulerInterface.cxx
@@ -38,7 +31,8 @@ vg_add_qt_plugin(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-  ${vsRuler_SdkTargets}
+  vspUserInterface
+  vtkVgQtUtil
   ${VTK_OPENGL_RENDERING_COMPONENTS}
   vtkGUISupportQt
 )

--- a/Plugins/VspUiExtensions/Ruler/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/Ruler/CMakeLists.txt
@@ -4,31 +4,13 @@ include_directories(SYSTEM
   ${VTK_INCLUDE_DIRS}
 )
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsRuler_Sources
   vsLineWidget.cxx
   vsRulerInterface.cxx
   vsRulerPlugin.cxx
 )
 
-set(vsRuler_MocHeaders
-  vsLineWidget.h
-  vsRulerInterface.h
-  vsRulerPlugin.h
-)
-
-qt5_wrap_cpp(vsRuler_MocSources
-  ${vsRuler_MocHeaders}
-)
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsRuler_Sources}
-  ${vsRuler_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsRuler_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vspUserInterface

--- a/Plugins/VspUiExtensions/TimelineViewer/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/TimelineViewer/CMakeLists.txt
@@ -9,11 +9,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-vg_include_library_sdk_directories(vspUserInterface
-  vtkVgQtUtil
-  QtVgCommon
-)
-
 set(vsTimelineViewerPlugin_Sources
   vsTimelineSelectionCallback.cxx
   vsTimelineViewer.cxx

--- a/Plugins/VspUiExtensions/TimelineViewer/CMakeLists.txt
+++ b/Plugins/VspUiExtensions/TimelineViewer/CMakeLists.txt
@@ -4,29 +4,13 @@ include_directories(SYSTEM
   ${VTK_INCLUDE_DIRS}
 )
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vsTimelineViewerPlugin_Sources
   vsTimelineSelectionCallback.cxx
   vsTimelineViewer.cxx
   vsTimelineViewerPlugin.cxx
 )
 
-set(vsTimelineViewerPlugin_MocHeaders
-  vsTimelineViewer.h
-  vsTimelineViewerPlugin.h
-)
-
-qt5_wrap_cpp(vsTimelineViewerPlugin_MocSources
-  ${vsTimelineViewerPlugin_MocHeaders})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vsTimelineViewerPlugin_Sources}
-  ${vsTimelineViewerPlugin_MocSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vsTimelineViewerPlugin_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vspUserInterface

--- a/Plugins/VvQueryService/FakeQueryService/CMakeLists.txt
+++ b/Plugins/VvQueryService/FakeQueryService/CMakeLists.txt
@@ -5,15 +5,6 @@ include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-set(vvFakeQueryService_SdkTargets
-  vvIO
-  vvWidgets
-  qtVgCommon
-  qtExtensions
-)
-
-vg_include_library_sdk_directories(${vvFakeQueryService_SdkTargets})
-
 set(vvFakeQueryService_Sources
   vvFakeQueryServerChooser.cxx
   vvFakeQueryServicePlugin.cxx
@@ -39,8 +30,11 @@ vg_add_qt_plugin(${PROJECT_NAME}
   ${vvFakeQueryService_UiSources}
 )
 
-target_link_libraries(${PROJECT_NAME} LINK_PRIVATE
-  ${vvFakeQueryService_SdkTargets}
+target_link_libraries(${PROJECT_NAME}
+  vvIO
+  vvWidgets
+  qtVgCommon
+  qtExtensions
 )
 
 install_plugin_targets(${PROJECT_NAME})

--- a/Plugins/VvQueryService/FakeQueryService/CMakeLists.txt
+++ b/Plugins/VvQueryService/FakeQueryService/CMakeLists.txt
@@ -1,34 +1,12 @@
 project(vvFakeQueryService)
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}
-)
-
 set(vvFakeQueryService_Sources
   vvFakeQueryServerChooser.cxx
   vvFakeQueryServicePlugin.cxx
   vvFakeQuerySession.cxx
 )
 
-set(vvFakeQueryService_MocHeaders
-  vvFakeQueryServerChooser.h
-  vvFakeQueryServicePlugin.h
-  vvFakeQuerySession.h
-)
-
-set(vvFakeQueryService_UiFiles
-  vvFakeQueryServerChooser.ui
-)
-
-qt5_wrap_cpp(vvFakeQueryService_MocSources ${vvFakeQueryService_MocHeaders})
-qt5_wrap_ui(vvFakeQueryService_UiSources ${vvFakeQueryService_UiFiles})
-
-vg_add_qt_plugin(${PROJECT_NAME}
-  ${vvFakeQueryService_Sources}
-  ${vvFakeQueryService_MocSources}
-  ${vvFakeQueryService_UiSources}
-)
+vg_add_qt_plugin(${PROJECT_NAME} ${vvFakeQueryService_Sources})
 
 target_link_libraries(${PROJECT_NAME}
   vvIO

--- a/Tools/ConvertTracks/CMakeLists.txt
+++ b/Tools/ConvertTracks/CMakeLists.txt
@@ -1,13 +1,12 @@
 project(convertTracks)
 
-vg_include_library_sdk_directories(qtExtensions)
-
 add_executable(${PROJECT_NAME} convertTracks.cxx)
 
-vg_add_dependencies(${PROJECT_NAME}
-  PRIVATE_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
   vgDataFramework
   vvIO
+  qtExtensionsHeaders
 )
 
 install_executable_target(${PROJECT_NAME} Tools)

--- a/Tools/DrawTracksOnFrame/CMakeLists.txt
+++ b/Tools/DrawTracksOnFrame/CMakeLists.txt
@@ -1,20 +1,18 @@
 project(drawTracksOnFrame)
 
-vg_include_library_sdk_directories(qtExtensions)
-
 add_executable(${PROJECT_NAME} drawTracksOnFrame.cxx)
 
 if(VISGUI_ENABLE_GDAL)
   set(vtkVgIO_LIBRARY vtkVgIO)
 endif()
 
-vg_add_dependencies(${PROJECT_NAME}
-  PRIVATE_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
   vgDataFramework
   ${vtkVgIO_LIBRARY}
   vtkVgModelView
   vtkVgCore
-  LINK_LIBRARIES LINK_PRIVATE
+  qtExtensionsHeaders
   ${VTK_OPENGL_RENDERING_COMPONENTS}
   vtkGUISupportQt
   vtkInteractionStyle

--- a/Tools/KwaTool/CMakeLists.txt
+++ b/Tools/KwaTool/CMakeLists.txt
@@ -4,12 +4,10 @@ set(SRCS kwaTool.cxx)
 
 add_executable(${PROJECT_NAME} ${SRCS})
 
-vg_add_dependencies(${PROJECT_NAME}
-  PRIVATE_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
   vgVideo
   qtExtensions
-  LINK_LIBRARIES LINK_PRIVATE
-  ${QT_LIBRARIES}
 )
 
 install_executable_target(${PROJECT_NAME} Tools)

--- a/Tools/MrjTranslator/CMakeLists.txt
+++ b/Tools/MrjTranslator/CMakeLists.txt
@@ -7,10 +7,8 @@ set(srcs MrjTranslator.cxx
 
 add_executable(${PROJECT_NAME} ${srcs})
 
-vg_add_dependencies(${PROJECT_NAME}
-  PUBLIC_INTERFACE_TARGETS
-  vtkVgCore
-  LINK_LIBRARIES LINK_PRIVATE
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
   vtkVgCore
   vtkCommonCore
   vtkCommonSystem

--- a/Tools/MrjTranslator/CMakeLists.txt
+++ b/Tools/MrjTranslator/CMakeLists.txt
@@ -1,11 +1,6 @@
-cmake_minimum_required(VERSION 2.8)
-
 project(mrjTranslator)
 
-set(srcs MrjTranslator.cxx
-)
-
-add_executable(${PROJECT_NAME} ${srcs})
+add_executable(${PROJECT_NAME} MrjTranslator.cxx)
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE

--- a/Tools/QSettingsTool/CMakeLists.txt
+++ b/Tools/QSettingsTool/CMakeLists.txt
@@ -2,8 +2,8 @@ project(qsettings-tool)
 
 add_executable(${PROJECT_NAME} qsettingsTool.cxx)
 
-vg_add_dependencies(${PROJECT_NAME}
-  PRIVATE_INTERFACE_TARGETS
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
   qtExtensions
   qtVgCommon
 )


### PR DESCRIPTION
Remove our home-grown system for specifying usage requirements (i.e. 'if you use this library, also use these include paths') and replace with use of CMake's native support. Replace use of qt wrapping macros with CMake's autogen support (necessary with the other changes in order to keep the build working; see commit messages for details).