### PR TITLE
Fix Unicode string literals on MSVC

### DIFF
--- a/Applications/VsPlay/Plugins/vsVvqsDatabaseSource.cxx
+++ b/Applications/VsPlay/Plugins/vsVvqsDatabaseSource.cxx
@@ -312,7 +312,7 @@ QString vsVvqsDatabaseSourcePrivate::displayableRequestUri() const
 {
   // Separate query items with zero-width space for better line breaking
   QString uri = this->RequestUri.toString();
-  static const auto replacement = QStringLiteral("\u200b\\1");
+  static const auto replacement = QStringLiteral(u"\u200b\\1");
   return uri.replace(QRegExp(QStringLiteral("([?&])")), replacement);
 }
 

--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -45,7 +45,13 @@ else()
 endif()
 
 # Set extra compiler flags
-if(NOT MSVC)
+if(MSVC)
+  # Turn on additional warnings-as-errors
+  vg_add_cxx_flags(
+    # Character cannot be represented in current code page
+    -we4566
+  )
+else()
   # Determine what flags (if any) are needed for required C++ language support
   # Note: MSVC always uses latest known C++ extensions
   vg_add_cxx_flags_priority(-std=c++11 -std=c++0x)

--- a/Libraries/QtVgCommon/vgGeoUtil.cxx
+++ b/Libraries/QtVgCommon/vgGeoUtil.cxx
@@ -116,10 +116,10 @@ QString dmsString(double coord, const QString& dp, const QString& dn,
       resultTemplate = QStringLiteral("%1d%2\'%3\"%4");
       break;
     case vgGeodesy::FormatDmsLatin1:
-      resultTemplate = QStringLiteral("%1\u00b0%2\'%3\"%4");
+      resultTemplate = QStringLiteral(u"%1\u00b0%2\'%3\"%4");
       break;
     case vgGeodesy::FormatDmsUnicode:
-      resultTemplate = QStringLiteral("%1\u00b0%2\u2032%3\u2033%4");
+      resultTemplate = QStringLiteral(u"%1\u00b0%2\u2032%3\u2033%4");
       break;
     default:
       qWarning().nospace() << __FUNCTION__ << ": invalid format mode " << fm;

--- a/Libraries/VvVtkWidgets/vvVideoQueryDialogPrivate.cxx
+++ b/Libraries/VvVtkWidgets/vvVideoQueryDialogPrivate.cxx
@@ -293,7 +293,7 @@ void vvVideoQueryDialogPrivate::setTimeConstraint(
 void vvVideoQueryDialogPrivate::updateKeyframeItem(
   QTreeWidgetItem* item, vtkIdType id, const vgRegionKeyframe& keyframe)
 {
-  static const auto name = QStringLiteral("%1,%2 %3\u00d7%4");
+  static const auto name = QStringLiteral(u"%1,%2 %3\u00d7%4");
   QRect r = keyframe.Region;
   item->setText(NameColumn, QStringLiteral("keyframe-") + QString::number(id));
   item->setText(RegionColumn, name.arg(r.left()).arg(r.top())

--- a/Libraries/VvWidgets/vvDescriptorInfoWidget.cxx
+++ b/Libraries/VvWidgets/vvDescriptorInfoWidget.cxx
@@ -134,7 +134,7 @@ void vvDescriptorInfoWidget::setDescriptor(vvDescriptor newDescriptor)
   // Regions
   qtDelayTreeSorting rds(d->UI.regions);
   d->UI.regions->clear();
-  static const auto rf = QStringLiteral("%1,%2 %3\u00d7%4");
+  static const auto rf = QStringLiteral(u"%1,%2 %3\u00d7%4");
   foreach_iter (vvDescriptorRegionMap::const_iterator, iter,
                 newDescriptor.Region)
     {

--- a/Libraries/VvWidgets/vvTrackInfoWidget.cxx
+++ b/Libraries/VvWidgets/vvTrackInfoWidget.cxx
@@ -108,9 +108,9 @@ void vvTrackInfoWidget::setTrack(vvTrack newTrack)
   // Trajectory states
   qtDelayTreeSorting tds(d->UI.trajectoryStates);
   d->UI.trajectoryStates->clear();
-  static const auto rf = QStringLiteral("%1,%2 %3\u00d7%4");
-  static const auto pf = QStringLiteral("%1, %2");
-  static const auto wf = QStringLiteral("%1:%2E,%3N");
+  static const auto rf = QStringLiteral(u"%1,%2 %3\u00d7%4");
+  static const auto pf = QStringLiteral(u"%1, %2");
+  static const auto wf = QStringLiteral(u"%1:%2E,%3N");
   foreach_iter (vvTrackTrajectory::const_iterator, iter, newTrack.Trajectory)
     {
     QTreeWidgetItem* item = new QTreeWidgetItem;


### PR DESCRIPTION
Due to the combined quirkiness of how VS processes string literals and how [QStringLiteral](https://doc.qt.io/qt-5/qstring.html#QStringLiteral) (or more specifically, [QT_UNICODE_LITERAL](/qt/qtbase/blob/287ace562ee5ddff22f7dbf4e49ae5f0520f2308/src/corelib/text/qstringliteral.h#L63)) is implemented, Visual Studio clobbers characters that are outside the local code page in certain uses of QStringLiteral. This happens because QT_UNICODE_LITERAL does not actually force the literal to be UTF-16, but rather prepends it with a UTF-16 literal, relying on concatenation promotion to make the remaining string also UTF-16. However, by the time that happens, Visual Studio has already corrupted the literal data.

The work-around is to prefix the actual literal (i.e. `u"foo"` instead of `"foo"` inside of QStringLiteral).

Additionally, turn the warning about this ([C4566](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4566?view=vs-2019)) into an error, which should hopefully prevent this from happening.