### PR TITLE
Fix installation of AUTOUIC headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Root cmake file.
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 
 project(visGUI)
 

--- a/Libraries/VvVtkWidgets/CMakeLists.txt
+++ b/Libraries/VvVtkWidgets/CMakeLists.txt
@@ -27,6 +27,15 @@ set(vvVtkWidgetsSources
   vvVideoQueryDialogPrivate.cxx
 )
 
+get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_is_multi_config)
+  set(${PROJECT_NAME}_AUTOGEN_INCLUDE_DIR
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include_$<CONFIG>)
+else()
+  set(${PROJECT_NAME}_AUTOGEN_INCLUDE_DIR
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_autogen/include)
+endif()
+
 set(vvVtkWidgetsInstallHeaders
   vvAbstractSimilarityQueryDialog.h
   vvClipVideoRepresentation.h
@@ -41,8 +50,8 @@ set(vvVtkWidgetsInstallHeaders
   vvVideoPlayerPrivate.h
   vvVideoQueryDialog.h
   vvVideoQueryDialogPrivate.h
-  ${CMAKE_CURRENT_BINARY_DIR}/ui_videoQuery.h
-  ${CMAKE_CURRENT_BINARY_DIR}/ui_videoView.h
+  ${${PROJECT_NAME}_AUTOGEN_INCLUDE_DIR}/ui_videoQuery.h
+  ${${PROJECT_NAME}_AUTOGEN_INCLUDE_DIR}/ui_videoView.h
 )
 
 #END common sources


### PR DESCRIPTION
Fix a build breakage that was introduced by 5fe5f442c741, due to the location of uic-generated headers changing with the switch from manual use of qtX_wrap_ui to AUTOUIC. This happened because, unfortunately, we have "private" headers that are used by subclasses across a library boundary that necessitate that the UI headers are also externally visible.

Reviews by @mathstuf and/or @dstoup would also be appreciated.