### PR TITLE
Revert "Kwiver recently discarded detected_object_type (#69)"

### DIFF
--- a/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
+++ b/Applications/VpView/vpKwiverEmbeddedPipelineWorker.cxx
@@ -1,5 +1,5 @@
 /*ckwg +5
- * Copyright 2020 by Kitware, Inc. All Rights Reserved. Please refer to
+ * Copyright 2019 by Kitware, Inc. All Rights Reserved. Please refer to
  * KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
@@ -24,7 +24,6 @@
 
 #include <sprokit/processes/adapters/embedded_pipeline.h>
 
-#include <vital/types/class_map.h>
 #include <vital/types/object_track_set.h>
 
 #include <arrows/vxl/image_io.h>
@@ -71,7 +70,7 @@ kv::track_sptr convertTrack(
   // Generate object type classifier
   auto const& toc = getTrackToc(in);
   auto dotp =
-    (!toc.empty() ? std::make_shared<kv::class_map>() : nullptr);
+    (!toc.empty() ? std::make_shared<kv::detected_object_type>() : nullptr);
   for (auto const& c : toc)
   {
     auto const& n = std::string{trackTypes->GetEntityType(c.first).GetName()};


### PR DESCRIPTION
Revert commit 9a4b54076e3d588f2dcbec3ad0777e6e8d06ad51. The upstream (KWIVER) changes caused issues due to conflation of detected object and activity types, due to which `class_map` was refactored to be a base class, and the original `detected_object_type` was reintroduced. Since this means that consumers do not need to be modified, revert the prior changes.

@dstoup, PTAL; thanks!