### PR TITLE
Fix two issues with KWAs

### DIFF
--- a/Libraries/VgVideo/vgKwaArchive.cxx
+++ b/Libraries/VgVideo/vgKwaArchive.cxx
@@ -182,8 +182,9 @@ vgKwaVideoClip* vgKwaArchivePrivate::findClip(
         }
       }
 
-    const double clipStart = clip->firstTime().Time;
-    const double clipEnd = clip->lastTime().Time;
+    constexpr auto epsilon = vgKwaVideoClip::timeEpsilon;
+    const double clipStart = clip->firstTime().Time * (1.0 - epsilon);
+    const double clipEnd = clip->lastTime().Time * (1.0 + epsilon);
 
     // Check for overlap
     if (clipStart <= requestEnd || clipEnd >= requestStart)

--- a/Libraries/VgVideo/vgKwaFrameMetadata.cxx
+++ b/Libraries/VgVideo/vgKwaFrameMetadata.cxx
@@ -77,22 +77,29 @@ vgKwaFrameMetadata::vgKwaFrameMetadata(
 
   d->homography = vgMatrix3d{homography.data_block()};
 
-  double max = qMax(qMax(qMax(corners[0][0], corners[0][1]),
-                         qMax(corners[1][0], corners[1][1])),
-                    qMax(qMax(corners[2][0], corners[2][1]),
-                         qMax(corners[3][0], corners[3][1])));
-
-  if (max < 400)
+  if (!corners.empty())
     {
-    d->worldCornerPoints.GCS = 4326;
-    d->worldCornerPoints.UpperLeft.Latitude   = corners[0][0];
-    d->worldCornerPoints.UpperLeft.Longitude  = corners[0][1];
-    d->worldCornerPoints.UpperRight.Latitude  = corners[1][0];
-    d->worldCornerPoints.UpperRight.Longitude = corners[1][1];
-    d->worldCornerPoints.LowerLeft.Latitude   = corners[2][0];
-    d->worldCornerPoints.LowerLeft.Longitude  = corners[2][1];
-    d->worldCornerPoints.LowerRight.Latitude  = corners[3][0];
-    d->worldCornerPoints.LowerRight.Longitude = corners[3][1];
+    double max = qMax(qMax(qMax(corners[0][0], corners[0][1]),
+                           qMax(corners[1][0], corners[1][1])),
+                      qMax(qMax(corners[2][0], corners[2][1]),
+                           qMax(corners[3][0], corners[3][1])));
+
+    if (max < 400)
+      {
+      d->worldCornerPoints.GCS = 4326;
+      d->worldCornerPoints.UpperLeft.Latitude   = corners[0][0];
+      d->worldCornerPoints.UpperLeft.Longitude  = corners[0][1];
+      d->worldCornerPoints.UpperRight.Latitude  = corners[1][0];
+      d->worldCornerPoints.UpperRight.Longitude = corners[1][1];
+      d->worldCornerPoints.LowerLeft.Latitude   = corners[2][0];
+      d->worldCornerPoints.LowerLeft.Longitude  = corners[2][1];
+      d->worldCornerPoints.LowerRight.Latitude  = corners[3][0];
+      d->worldCornerPoints.LowerRight.Longitude = corners[3][1];
+      }
+    else
+      {
+      d->worldCornerPoints.GCS = -1;
+      }
     }
   else
     {

--- a/Libraries/VgVideo/vgKwaVideoClip.h
+++ b/Libraries/VgVideo/vgKwaVideoClip.h
@@ -20,6 +20,9 @@ class VG_VIDEO_EXPORT vgKwaVideoClip : public vgVideo
 public:
   typedef vgTimeMap<vgKwaFrameMetadata> MetadataMap;
 
+  /// Factor used to "fuzz" times to account for floating point errors.
+  static constexpr auto timeEpsilon = 1e-15;
+
   explicit vgKwaVideoClip(const QUrl& indexUri);
   virtual ~vgKwaVideoClip();
 


### PR DESCRIPTION
Modify KWA metadata reader to not crash if the corner points are not present. Modify various bits of the KWA clip-finding logic to add some fuzzing to account for floating-point precision issues that could cause lookup and padding resolution to incorrectly fail, particularly for single-frame requests at the start or end of the KWA.