### PR TITLE
[VIAME] Cherry-pick most of #70 ("Assorted fixes")

### DIFF
--- a/Libraries/VgCommon/vgGeodesy.cxx
+++ b/Libraries/VgCommon/vgGeodesy.cxx
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <string>
 
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
 #include <proj_api.h>
 
 #include <GeographicLib/GeoCoords.hpp>

--- a/Libraries/VspUserInterface/vsScenePrivate.h
+++ b/Libraries/VspUserInterface/vsScenePrivate.h
@@ -8,6 +8,7 @@
 #define __vsScenePrivate_h
 
 #include <QHash>
+#include <QMap>
 #include <QMatrix4x4>
 #include <QPoint>
 #include <QSet>

--- a/Libraries/VvIO/vvCompare.cxx
+++ b/Libraries/VvIO/vvCompare.cxx
@@ -14,8 +14,8 @@ bool operator==(const vvDescriptorRegionEntry& a,
 {
   return a.ImageRegion.TopLeft.X == b.ImageRegion.TopLeft.X &&
          a.ImageRegion.TopLeft.Y == b.ImageRegion.TopLeft.Y &&
-         a.ImageRegion.BottomRight.X == a.ImageRegion.BottomRight.X &&
-         a.ImageRegion.BottomRight.Y == a.ImageRegion.BottomRight.Y &&
+         a.ImageRegion.BottomRight.X == b.ImageRegion.BottomRight.X &&
+         a.ImageRegion.BottomRight.Y == b.ImageRegion.BottomRight.Y &&
          qFuzzyCompare(a.TimeStamp.Time, b.TimeStamp.Time) &&
          (!(a.TimeStamp.HasFrameNumber() && b.TimeStamp.HasFrameNumber())
           || (a.TimeStamp.FrameNumber == b.TimeStamp.FrameNumber));

--- a/Plugins/VspSourceService/TrackOracleArchiveSource/visgui_event_type.h
+++ b/Plugins/VspSourceService/TrackOracleArchiveSource/visgui_event_type.h
@@ -17,30 +17,30 @@
 #include <track_oracle/track_field.h>
 #endif
 
-#include <vgl/vgl_box_2d.h>
+#include <track_oracle/data_terms/data_terms.h>
 
 //-----------------------------------------------------------------------------
 struct visgui_classifier_descriptor_type :
   public track_oracle::track_base<visgui_classifier_descriptor_type>
 {
-  track_oracle::track_field<unsigned int>& external_id;
-  track_oracle::track_field<std::vector<unsigned int>>& source_track_ids;
-  track_oracle::track_field<std::vector<double>>& descriptor_classifier;
+  TRACK_ORACLE_FIELD(tracking, external_id);
+  TRACK_ORACLE_FIELD(events, source_track_ids);
+  TRACK_ORACLE_FIELD(virat, descriptor_classifier);
 
-  track_oracle::track_field<unsigned int>& frame_number;
-  track_oracle::track_field<unsigned long long>& timestamp_usecs;
-  track_oracle::track_field<vgl_box_2d<double>>& bounding_box;
+  TRACK_ORACLE_FIELD(tracking, frame_number);
+  TRACK_ORACLE_FIELD(tracking, timestamp_usecs);
+  TRACK_ORACLE_FIELD(tracking, bounding_box);
 
-  visgui_classifier_descriptor_type() :
-    TRACK_ORACLE_INIT_FIELD(Track, external_id),
-    TRACK_ORACLE_INIT_FIELD(Track, source_track_ids),
-    TRACK_ORACLE_INIT_FIELD(Track, descriptor_classifier),
+  visgui_classifier_descriptor_type()
+  {
+    Track.add_field(external_id);
+    Track.add_field(source_track_ids);
+    Track.add_field(descriptor_classifier);
 
-    TRACK_ORACLE_INIT_FIELD(Frame, frame_number),
-    TRACK_ORACLE_INIT_FIELD(Frame, timestamp_usecs),
-    TRACK_ORACLE_INIT_FIELD(Frame, bounding_box)
-    {
-    }
+    Frame.add_field(frame_number);
+    Frame.add_field(timestamp_usecs);
+    Frame.add_field(bounding_box);
+  }
 };
 
 //-----------------------------------------------------------------------------
@@ -53,8 +53,8 @@ struct visgui_pvo_descriptor_type :
   visgui_pvo_descriptor_type() :
     TRACK_ORACLE_INIT_FIELD(Track, source_track_ids),
     TRACK_ORACLE_INIT_FIELD(Track, descriptor_pvo_raw_scores)
-    {
-    }
+  {
+  }
 };
 
 //-----------------------------------------------------------------------------
@@ -72,8 +72,8 @@ struct visgui_generic_event_type :
     TRACK_ORACLE_INIT_FIELD(Track, end_time_secs),
     TRACK_ORACLE_INIT_FIELD(Track, basic_annotation),
     TRACK_ORACLE_INIT_FIELD(Track, augmented_annotation)
-    {
-    }
+  {
+  }
 };
 
 #endif

--- a/Plugins/VspUiExtensions/ContextViewer/vsContextViewer.cxx
+++ b/Plugins/VspUiExtensions/ContextViewer/vsContextViewer.cxx
@@ -357,7 +357,8 @@ void vsContextViewerPrivate::updateMarker(
 {
   const vsDisplayInfo& info = (this->Scene->*getInfo)(markerInfo.EntityId);
 
-  const double* c = info.Color.value().array;
+  auto const& v = info.Color.value();
+  const double* c = v.array;
   markerInfo.Marker->SetVisibility(info.Visible);
   markerInfo.Marker->SetDefaultColor(c[0], c[1], c[2]);
 


### PR DESCRIPTION
This PR cherry-picks #70 excluding 9860b2ed1769f4fc821d9ac22f404556c7a10bde, which doesn't seem to apply here. In particular, this brings in 311785b17839a5d9ca017e9b7eb9849e442a1042, which stops Viqui from crashing when trying to perform a query due to `track_oracle`-related issues.

@mattdawkins